### PR TITLE
Switching to use pool.vmImage rather than pool.name

### DIFF
--- a/scripts/azure-pipelines.yml
+++ b/scripts/azure-pipelines.yml
@@ -2,28 +2,28 @@ jobs:
 - template: azure-windows.yml
   parameters:
     name: windows_debug_x86
-    pool: Hosted
+    pool: windows-latest
     configuration: Debug
     architecture: x86
 
 - template: azure-windows.yml
   parameters:
     name: windows_release_x86
-    pool: Hosted
+    pool: windows-latest
     configuration: Release
     architecture: x86
 
 - template: azure-windows.yml
   parameters:
     name: windows_debug_x64
-    pool: Hosted
+    pool: windows-latest
     configuration: Debug
     architecture: x64
 
 - template: azure-windows.yml
   parameters:
     name: windows_release_x64
-    pool: Hosted
+    pool: windows-latest
     configuration: Release
     architecture: x64
     publish: ${{parameters.ci}}
@@ -31,27 +31,27 @@ jobs:
 - template: azure-unix.yml
   parameters:
     name: ubuntu_debug_x64
-    pool: Hosted Ubuntu 1604
+    pool: ubuntu-latest
     configuration: Debug
     architecture: x64
 
 - template: azure-unix.yml
   parameters:
     name: ubuntu_release_x64
-    pool: Hosted Ubuntu 1604
+    pool: ubuntu-latest
     configuration: Release
     architecture: x64
 
 - template: azure-unix.yml
   parameters:
     name: macos_debug_x64
-    pool: Hosted macOS
+    pool: macOS-latest
     configuration: Debug
     architecture: x64
 
 - template: azure-unix.yml
   parameters:
     name: macos_release_x64
-    pool: Hosted macOS
+    pool: macOS-latest
     configuration: Release
     architecture: x64

--- a/scripts/azure-unix.yml
+++ b/scripts/azure-unix.yml
@@ -1,7 +1,7 @@
 jobs:
 - job: ${{parameters.name}}
   pool:
-    name: ${{parameters.pool}}
+    vmImage: ${{parameters.pool}}
   steps:
   - task: Bash@3
     displayName: 'Run scripts/cibuild.sh'

--- a/scripts/azure-windows.yml
+++ b/scripts/azure-windows.yml
@@ -1,8 +1,7 @@
 jobs:
 - job: ${{parameters.name}}
   pool:
-    name: ${{parameters.pool}}
-    demands: Cmd
+    vmImage: ${{parameters.pool}}
   steps:
   - task: BatchScript@1
     displayName: 'Run scripts/cibuild.cmd'


### PR DESCRIPTION
This moves the CI images forward.