### PR TITLE
Adding the ability for users to hook the DllImportResolver

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -19,8 +19,8 @@
 
   <!-- Package versions for package references across all projects -->
   <ItemGroup>
-    <PackageReference Update="Microsoft.Net.Compilers.Toolset" Version="3.4.0" />
-    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="16.4.0" />
+    <PackageReference Update="Microsoft.Net.Compilers.Toolset" Version="3.5.0-beta1-final" />
+    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="16.5.0-preview-20191115-01" />
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.0.0" />
     <PackageReference Update="NUnit" Version="3.12.0" />
     <PackageReference Update="NUnit3TestAdapter" Version="3.15.1" />

--- a/sources/Interop/Xlib/NativeTypeNameAttribute.cs
+++ b/sources/Interop/Xlib/NativeTypeNameAttribute.cs
@@ -6,7 +6,7 @@ using System.Diagnostics;
 namespace TerraFX.Interop
 {
     /// <summary>Defines the type of a member as it was used in the native signature.</summary>
-    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.ReturnValue, AllowMultiple = false, Inherited = true)]
+    [AttributeUsage(AttributeTargets.Enum | AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.ReturnValue, AllowMultiple = false, Inherited = true)]
     [Conditional("DEBUG")]
     internal sealed class NativeTypeNameAttribute : Attribute
     {

--- a/sources/Interop/Xlib/Xcms/Xlib.cs
+++ b/sources/Interop/Xlib/Xcms/Xlib.cs
@@ -10,222 +10,222 @@ namespace TerraFX.Interop
 {
     public static unsafe partial class Xlib
     {
-        [DllImport(libraryPath, EntryPoint = "XcmsAddColorSpace", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XcmsAddColorSpace", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XcmsAddColorSpace([NativeTypeName("XcmsColorSpace *")] XcmsColorSpace* pColorSpace);
 
-        [DllImport(libraryPath, EntryPoint = "XcmsAddFunctionSet", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XcmsAddFunctionSet", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XcmsAddFunctionSet([NativeTypeName("XcmsFunctionSet *")] XcmsFunctionSet* functionSet);
 
-        [DllImport(libraryPath, EntryPoint = "XcmsAllocColor", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XcmsAllocColor", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XcmsAllocColor([NativeTypeName("Display *")] UIntPtr dpy, [NativeTypeName("Colormap")] UIntPtr colormap, [NativeTypeName("XcmsColor *")] XcmsColor* color_in_out, [NativeTypeName("XcmsColorFormat")] UIntPtr result_format);
 
-        [DllImport(libraryPath, EntryPoint = "XcmsAllocNamedColor", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XcmsAllocNamedColor", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XcmsAllocNamedColor([NativeTypeName("Display *")] UIntPtr dpy, [NativeTypeName("Colormap")] UIntPtr colormap, [NativeTypeName("const char *")] sbyte* color_string, [NativeTypeName("XcmsColor *")] XcmsColor* color_scrn_return, [NativeTypeName("XcmsColor *")] XcmsColor* color_exact_return, [NativeTypeName("XcmsColorFormat")] UIntPtr result_format);
 
-        [DllImport(libraryPath, EntryPoint = "XcmsCCCOfColormap", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XcmsCCCOfColormap", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("XcmsCCC")]
         public static extern XcmsCCC* XcmsCCCOfColormap([NativeTypeName("Display *")] UIntPtr dpy, [NativeTypeName("Colormap")] UIntPtr colormap);
 
-        [DllImport(libraryPath, EntryPoint = "XcmsCIELabClipab", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XcmsCIELabClipab", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XcmsCIELabClipab([NativeTypeName("XcmsCCC")] XcmsCCC* ccc, [NativeTypeName("XcmsColor *")] XcmsColor* colors_in_out, [NativeTypeName("unsigned int")] uint ncolors, [NativeTypeName("unsigned int")] uint index, [NativeTypeName("int *")] int* compression_flags_return);
 
-        [DllImport(libraryPath, EntryPoint = "XcmsCIELabClipL", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XcmsCIELabClipL", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XcmsCIELabClipL([NativeTypeName("XcmsCCC")] XcmsCCC* ccc, [NativeTypeName("XcmsColor *")] XcmsColor* colors_in_out, [NativeTypeName("unsigned int")] uint ncolors, [NativeTypeName("unsigned int")] uint index, [NativeTypeName("int *")] int* compression_flags_return);
 
-        [DllImport(libraryPath, EntryPoint = "XcmsCIELabClipLab", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XcmsCIELabClipLab", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XcmsCIELabClipLab([NativeTypeName("XcmsCCC")] XcmsCCC* ccc, [NativeTypeName("XcmsColor *")] XcmsColor* colors_in_out, [NativeTypeName("unsigned int")] uint ncolors, [NativeTypeName("unsigned int")] uint index, [NativeTypeName("int *")] int* compression_flags_return);
 
-        [DllImport(libraryPath, EntryPoint = "XcmsCIELabQueryMaxC", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XcmsCIELabQueryMaxC", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XcmsCIELabQueryMaxC([NativeTypeName("XcmsCCC")] XcmsCCC* ccc, [NativeTypeName("XcmsFloat")] double hue_angle, [NativeTypeName("XcmsFloat")] double L_star, [NativeTypeName("XcmsColor *")] XcmsColor* color_return);
 
-        [DllImport(libraryPath, EntryPoint = "XcmsCIELabQueryMaxL", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XcmsCIELabQueryMaxL", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XcmsCIELabQueryMaxL([NativeTypeName("XcmsCCC")] XcmsCCC* ccc, [NativeTypeName("XcmsFloat")] double hue_angle, [NativeTypeName("XcmsFloat")] double chroma, [NativeTypeName("XcmsColor *")] XcmsColor* color_return);
 
-        [DllImport(libraryPath, EntryPoint = "XcmsCIELabQueryMaxLC", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XcmsCIELabQueryMaxLC", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XcmsCIELabQueryMaxLC([NativeTypeName("XcmsCCC")] XcmsCCC* ccc, [NativeTypeName("XcmsFloat")] double hue_angle, [NativeTypeName("XcmsColor *")] XcmsColor* color_return);
 
-        [DllImport(libraryPath, EntryPoint = "XcmsCIELabQueryMinL", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XcmsCIELabQueryMinL", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XcmsCIELabQueryMinL([NativeTypeName("XcmsCCC")] XcmsCCC* ccc, [NativeTypeName("XcmsFloat")] double hue_angle, [NativeTypeName("XcmsFloat")] double chroma, [NativeTypeName("XcmsColor *")] XcmsColor* color_return);
 
-        [DllImport(libraryPath, EntryPoint = "XcmsCIELabToCIEXYZ", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XcmsCIELabToCIEXYZ", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XcmsCIELabToCIEXYZ([NativeTypeName("XcmsCCC")] XcmsCCC* ccc, [NativeTypeName("XcmsColor *")] XcmsColor* white_point, [NativeTypeName("XcmsColor *")] XcmsColor* colors, [NativeTypeName("unsigned int")] uint ncolors);
 
-        [DllImport(libraryPath, EntryPoint = "XcmsCIELabWhiteShiftColors", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XcmsCIELabWhiteShiftColors", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XcmsCIELabWhiteShiftColors([NativeTypeName("XcmsCCC")] XcmsCCC* ccc, [NativeTypeName("XcmsColor *")] XcmsColor* initial_white_point, [NativeTypeName("XcmsColor *")] XcmsColor* target_white_point, [NativeTypeName("XcmsColorFormat")] UIntPtr target_format, [NativeTypeName("XcmsColor *")] XcmsColor* colors_in_out, [NativeTypeName("unsigned int")] uint ncolors, [NativeTypeName("int *")] int* compression_flags_return);
 
-        [DllImport(libraryPath, EntryPoint = "XcmsCIELuvClipL", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XcmsCIELuvClipL", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XcmsCIELuvClipL([NativeTypeName("XcmsCCC")] XcmsCCC* ccc, [NativeTypeName("XcmsColor *")] XcmsColor* colors_in_out, [NativeTypeName("unsigned int")] uint ncolors, [NativeTypeName("unsigned int")] uint index, [NativeTypeName("int *")] int* compression_flags_return);
 
-        [DllImport(libraryPath, EntryPoint = "XcmsCIELuvClipLuv", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XcmsCIELuvClipLuv", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XcmsCIELuvClipLuv([NativeTypeName("XcmsCCC")] XcmsCCC* ccc, [NativeTypeName("XcmsColor *")] XcmsColor* colors_in_out, [NativeTypeName("unsigned int")] uint ncolors, [NativeTypeName("unsigned int")] uint index, [NativeTypeName("int *")] int* compression_flags_return);
 
-        [DllImport(libraryPath, EntryPoint = "XcmsCIELuvClipuv", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XcmsCIELuvClipuv", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XcmsCIELuvClipuv([NativeTypeName("XcmsCCC")] XcmsCCC* ccc, [NativeTypeName("XcmsColor *")] XcmsColor* colors_in_out, [NativeTypeName("unsigned int")] uint ncolors, [NativeTypeName("unsigned int")] uint index, [NativeTypeName("int *")] int* compression_flags_return);
 
-        [DllImport(libraryPath, EntryPoint = "XcmsCIELuvQueryMaxC", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XcmsCIELuvQueryMaxC", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XcmsCIELuvQueryMaxC([NativeTypeName("XcmsCCC")] XcmsCCC* ccc, [NativeTypeName("XcmsFloat")] double hue_angle, [NativeTypeName("XcmsFloat")] double L_star, [NativeTypeName("XcmsColor *")] XcmsColor* color_return);
 
-        [DllImport(libraryPath, EntryPoint = "XcmsCIELuvQueryMaxL", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XcmsCIELuvQueryMaxL", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XcmsCIELuvQueryMaxL([NativeTypeName("XcmsCCC")] XcmsCCC* ccc, [NativeTypeName("XcmsFloat")] double hue_angle, [NativeTypeName("XcmsFloat")] double chroma, [NativeTypeName("XcmsColor *")] XcmsColor* color_return);
 
-        [DllImport(libraryPath, EntryPoint = "XcmsCIELuvQueryMaxLC", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XcmsCIELuvQueryMaxLC", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XcmsCIELuvQueryMaxLC([NativeTypeName("XcmsCCC")] XcmsCCC* ccc, [NativeTypeName("XcmsFloat")] double hue_angle, [NativeTypeName("XcmsColor *")] XcmsColor* color_return);
 
-        [DllImport(libraryPath, EntryPoint = "XcmsCIELuvQueryMinL", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XcmsCIELuvQueryMinL", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XcmsCIELuvQueryMinL([NativeTypeName("XcmsCCC")] XcmsCCC* ccc, [NativeTypeName("XcmsFloat")] double hue_angle, [NativeTypeName("XcmsFloat")] double chroma, [NativeTypeName("XcmsColor *")] XcmsColor* color_return);
 
-        [DllImport(libraryPath, EntryPoint = "XcmsCIELuvToCIEuvY", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XcmsCIELuvToCIEuvY", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XcmsCIELuvToCIEuvY([NativeTypeName("XcmsCCC")] XcmsCCC* ccc, [NativeTypeName("XcmsColor *")] XcmsColor* white_point, [NativeTypeName("XcmsColor *")] XcmsColor* colors, [NativeTypeName("unsigned int")] uint ncolors);
 
-        [DllImport(libraryPath, EntryPoint = "XcmsCIELuvWhiteShiftColors", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XcmsCIELuvWhiteShiftColors", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XcmsCIELuvWhiteShiftColors([NativeTypeName("XcmsCCC")] XcmsCCC* ccc, [NativeTypeName("XcmsColor *")] XcmsColor* initial_white_point, [NativeTypeName("XcmsColor *")] XcmsColor* target_white_point, [NativeTypeName("XcmsColorFormat")] UIntPtr target_format, [NativeTypeName("XcmsColor *")] XcmsColor* colors_in_out, [NativeTypeName("unsigned int")] uint ncolors, [NativeTypeName("int *")] int* compression_flags_return);
 
-        [DllImport(libraryPath, EntryPoint = "XcmsCIEXYZToCIELab", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XcmsCIEXYZToCIELab", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XcmsCIEXYZToCIELab([NativeTypeName("XcmsCCC")] XcmsCCC* ccc, [NativeTypeName("XcmsColor *")] XcmsColor* white_point, [NativeTypeName("XcmsColor *")] XcmsColor* colors, [NativeTypeName("unsigned int")] uint ncolors);
 
-        [DllImport(libraryPath, EntryPoint = "XcmsCIEXYZToCIEuvY", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XcmsCIEXYZToCIEuvY", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XcmsCIEXYZToCIEuvY([NativeTypeName("XcmsCCC")] XcmsCCC* ccc, [NativeTypeName("XcmsColor *")] XcmsColor* white_point, [NativeTypeName("XcmsColor *")] XcmsColor* colors, [NativeTypeName("unsigned int")] uint ncolors);
 
-        [DllImport(libraryPath, EntryPoint = "XcmsCIEXYZToCIExyY", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XcmsCIEXYZToCIExyY", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XcmsCIEXYZToCIExyY([NativeTypeName("XcmsCCC")] XcmsCCC* ccc, [NativeTypeName("XcmsColor *")] XcmsColor* white_point, [NativeTypeName("XcmsColor *")] XcmsColor* colors, [NativeTypeName("unsigned int")] uint ncolors);
 
-        [DllImport(libraryPath, EntryPoint = "XcmsCIEXYZToRGBi", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XcmsCIEXYZToRGBi", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XcmsCIEXYZToRGBi([NativeTypeName("XcmsCCC")] XcmsCCC* ccc, [NativeTypeName("XcmsColor *")] XcmsColor* colors, [NativeTypeName("unsigned int")] uint ncolors, [NativeTypeName("int *")] int* compression_flags_return);
 
-        [DllImport(libraryPath, EntryPoint = "XcmsCIEuvYToCIELuv", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XcmsCIEuvYToCIELuv", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XcmsCIEuvYToCIELuv([NativeTypeName("XcmsCCC")] XcmsCCC* ccc, [NativeTypeName("XcmsColor *")] XcmsColor* white_point, [NativeTypeName("XcmsColor *")] XcmsColor* colors, [NativeTypeName("unsigned int")] uint ncolors);
 
-        [DllImport(libraryPath, EntryPoint = "XcmsCIEuvYToCIEXYZ", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XcmsCIEuvYToCIEXYZ", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XcmsCIEuvYToCIEXYZ([NativeTypeName("XcmsCCC")] XcmsCCC* ccc, [NativeTypeName("XcmsColor *")] XcmsColor* white_point, [NativeTypeName("XcmsColor *")] XcmsColor* colors, [NativeTypeName("unsigned int")] uint ncolors);
 
-        [DllImport(libraryPath, EntryPoint = "XcmsCIEuvYToTekHVC", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XcmsCIEuvYToTekHVC", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XcmsCIEuvYToTekHVC([NativeTypeName("XcmsCCC")] XcmsCCC* ccc, [NativeTypeName("XcmsColor *")] XcmsColor* white_point, [NativeTypeName("XcmsColor *")] XcmsColor* colors, [NativeTypeName("unsigned int")] uint ncolors);
 
-        [DllImport(libraryPath, EntryPoint = "XcmsCIExyYToCIEXYZ", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XcmsCIExyYToCIEXYZ", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XcmsCIExyYToCIEXYZ([NativeTypeName("XcmsCCC")] XcmsCCC* ccc, [NativeTypeName("XcmsColor *")] XcmsColor* white_point, [NativeTypeName("XcmsColor *")] XcmsColor* colors, [NativeTypeName("unsigned int")] uint ncolors);
 
-        [DllImport(libraryPath, EntryPoint = "XcmsClientWhitePointOfCCC", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XcmsClientWhitePointOfCCC", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("XcmsColor *")]
         public static extern XcmsColor* XcmsClientWhitePointOfCCC([NativeTypeName("XcmsCCC")] XcmsCCC* ccc);
 
-        [DllImport(libraryPath, EntryPoint = "XcmsConvertColors", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XcmsConvertColors", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XcmsConvertColors([NativeTypeName("XcmsCCC")] XcmsCCC* ccc, [NativeTypeName("XcmsColor *")] XcmsColor* colorArry_in_out, [NativeTypeName("unsigned int")] uint nColors, [NativeTypeName("XcmsColorFormat")] UIntPtr targetFormat, [NativeTypeName("int *")] int* compArry_return);
 
-        [DllImport(libraryPath, EntryPoint = "XcmsCreateCCC", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XcmsCreateCCC", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("XcmsCCC")]
         public static extern XcmsCCC* XcmsCreateCCC([NativeTypeName("Display *")] UIntPtr dpy, int screenNumber, [NativeTypeName("Visual *")] Visual* visual, [NativeTypeName("XcmsColor *")] XcmsColor* clientWhitePt, [NativeTypeName("XcmsCompressionProc")] IntPtr gamutCompProc, [NativeTypeName("XPointer")] sbyte* gamutCompClientData, [NativeTypeName("XcmsWhiteAdjustProc")] IntPtr whitePtAdjProc, [NativeTypeName("XPointer")] sbyte* whitePtAdjClientData);
 
-        [DllImport(libraryPath, EntryPoint = "XcmsDefaultCCC", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XcmsDefaultCCC", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("XcmsCCC")]
         public static extern XcmsCCC* XcmsDefaultCCC([NativeTypeName("Display *")] UIntPtr dpy, int screenNumber);
 
-        [DllImport(libraryPath, EntryPoint = "XcmsDisplayOfCCC", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XcmsDisplayOfCCC", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("Display *")]
         public static extern UIntPtr XcmsDisplayOfCCC([NativeTypeName("XcmsCCC")] XcmsCCC* ccc);
 
-        [DllImport(libraryPath, EntryPoint = "XcmsFormatOfPrefix", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XcmsFormatOfPrefix", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("XcmsColorFormat")]
         public static extern UIntPtr XcmsFormatOfPrefix([NativeTypeName("char *")] sbyte* prefix);
 
-        [DllImport(libraryPath, EntryPoint = "XcmsFreeCCC", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XcmsFreeCCC", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void XcmsFreeCCC([NativeTypeName("XcmsCCC")] XcmsCCC* ccc);
 
-        [DllImport(libraryPath, EntryPoint = "XcmsLookupColor", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XcmsLookupColor", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XcmsLookupColor([NativeTypeName("Display *")] UIntPtr dpy, [NativeTypeName("Colormap")] UIntPtr colormap, [NativeTypeName("const char *")] sbyte* color_string, [NativeTypeName("XcmsColor *")] XcmsColor* pColor_exact_in_out, [NativeTypeName("XcmsColor *")] XcmsColor* pColor_scrn_in_out, [NativeTypeName("XcmsColorFormat")] UIntPtr result_format);
 
-        [DllImport(libraryPath, EntryPoint = "XcmsPrefixOfFormat", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XcmsPrefixOfFormat", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("char *")]
         public static extern sbyte* XcmsPrefixOfFormat([NativeTypeName("XcmsColorFormat")] UIntPtr id);
 
-        [DllImport(libraryPath, EntryPoint = "XcmsQueryBlack", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XcmsQueryBlack", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XcmsQueryBlack([NativeTypeName("XcmsCCC")] XcmsCCC* ccc, [NativeTypeName("XcmsColorFormat")] UIntPtr target_format, [NativeTypeName("XcmsColor *")] XcmsColor* color_return);
 
-        [DllImport(libraryPath, EntryPoint = "XcmsQueryBlue", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XcmsQueryBlue", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XcmsQueryBlue([NativeTypeName("XcmsCCC")] XcmsCCC* ccc, [NativeTypeName("XcmsColorFormat")] UIntPtr target_format, [NativeTypeName("XcmsColor *")] XcmsColor* color_return);
 
-        [DllImport(libraryPath, EntryPoint = "XcmsQueryColor", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XcmsQueryColor", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XcmsQueryColor([NativeTypeName("Display *")] UIntPtr dpu, [NativeTypeName("Colormap")] UIntPtr colormap, [NativeTypeName("XcmsColor *")] XcmsColor* pColor_in_out, [NativeTypeName("XcmsColorFormat")] UIntPtr result_format);
 
-        [DllImport(libraryPath, EntryPoint = "XcmsQueryColors", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XcmsQueryColors", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XcmsQueryColors([NativeTypeName("Display *")] UIntPtr dpy, [NativeTypeName("Colormap")] UIntPtr colormap, [NativeTypeName("XcmsColor *")] XcmsColor* colorArry_in_out, [NativeTypeName("unsigned int")] uint nColors, [NativeTypeName("XcmsColorFormat")] UIntPtr result_format);
 
-        [DllImport(libraryPath, EntryPoint = "XcmsQueryGreen", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XcmsQueryGreen", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XcmsQueryGreen([NativeTypeName("XcmsCCC")] XcmsCCC* ccc, [NativeTypeName("XcmsColorFormat")] UIntPtr target_format, [NativeTypeName("XcmsColor *")] XcmsColor* color_return);
 
-        [DllImport(libraryPath, EntryPoint = "XcmsQueryRed", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XcmsQueryRed", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XcmsQueryRed([NativeTypeName("XcmsCCC")] XcmsCCC* ccc, [NativeTypeName("XcmsColorFormat")] UIntPtr target_format, [NativeTypeName("XcmsColor *")] XcmsColor* color_return);
 
-        [DllImport(libraryPath, EntryPoint = "XcmsQueryWhite", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XcmsQueryWhite", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XcmsQueryWhite([NativeTypeName("XcmsCCC")] XcmsCCC* ccc, [NativeTypeName("XcmsColorFormat")] UIntPtr target_format, [NativeTypeName("XcmsColor *")] XcmsColor* color_return);
 
-        [DllImport(libraryPath, EntryPoint = "XcmsRGBiToCIEXYZ", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XcmsRGBiToCIEXYZ", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XcmsRGBiToCIEXYZ([NativeTypeName("XcmsCCC")] XcmsCCC* ccc, [NativeTypeName("XcmsColor *")] XcmsColor* colors, [NativeTypeName("unsigned int")] uint ncolors, [NativeTypeName("int *")] int* compression_flags_return);
 
-        [DllImport(libraryPath, EntryPoint = "XcmsRGBiToRGB", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XcmsRGBiToRGB", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XcmsRGBiToRGB([NativeTypeName("XcmsCCC")] XcmsCCC* ccc, [NativeTypeName("XcmsColor *")] XcmsColor* colors, [NativeTypeName("unsigned int")] uint ncolors, [NativeTypeName("int *")] int* compression_flags_return);
 
-        [DllImport(libraryPath, EntryPoint = "XcmsRGBToRGBi", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XcmsRGBToRGBi", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XcmsRGBToRGBi([NativeTypeName("XcmsCCC")] XcmsCCC* ccc, [NativeTypeName("XcmsColor *")] XcmsColor* colors, [NativeTypeName("unsigned int")] uint ncolors, [NativeTypeName("int *")] int* compression_flags_return);
 
-        [DllImport(libraryPath, EntryPoint = "XcmsScreenNumberOfCCC", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XcmsScreenNumberOfCCC", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XcmsScreenNumberOfCCC([NativeTypeName("XcmsCCC")] XcmsCCC* ccc);
 
-        [DllImport(libraryPath, EntryPoint = "XcmsScreenWhitePointOfCCC", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XcmsScreenWhitePointOfCCC", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("XcmsColor *")]
         public static extern XcmsColor* XcmsScreenWhitePointOfCCC([NativeTypeName("XcmsCCC")] XcmsCCC* ccc);
 
-        [DllImport(libraryPath, EntryPoint = "XcmsSetCCCOfColormap", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XcmsSetCCCOfColormap", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("XcmsCCC")]
         public static extern XcmsCCC* XcmsSetCCCOfColormap([NativeTypeName("Display *")] UIntPtr dpy, [NativeTypeName("Colormap")] UIntPtr colormap, [NativeTypeName("XcmsCCC")] XcmsCCC* ccc);
 
-        [DllImport(libraryPath, EntryPoint = "XcmsSetCompressionProc", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XcmsSetCompressionProc", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("XcmsCompressionProc")]
         public static extern IntPtr XcmsSetCompressionProc([NativeTypeName("XcmsCCC")] XcmsCCC* ccc, [NativeTypeName("XcmsCompressionProc")] IntPtr compression_proc, [NativeTypeName("XPointer")] sbyte* client_data);
 
-        [DllImport(libraryPath, EntryPoint = "XcmsSetWhiteAdjustProc", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XcmsSetWhiteAdjustProc", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("XcmsWhiteAdjustProc")]
         public static extern IntPtr XcmsSetWhiteAdjustProc([NativeTypeName("XcmsCCC")] XcmsCCC* ccc, [NativeTypeName("XcmsWhiteAdjustProc")] IntPtr white_adjust_proc, [NativeTypeName("XPointer")] sbyte* client_data);
 
-        [DllImport(libraryPath, EntryPoint = "XcmsSetWhitePoint", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XcmsSetWhitePoint", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XcmsSetWhitePoint([NativeTypeName("XcmsCCC")] XcmsCCC* ccc, [NativeTypeName("XcmsColor *")] XcmsColor* color);
 
-        [DllImport(libraryPath, EntryPoint = "XcmsStoreColor", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XcmsStoreColor", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XcmsStoreColor([NativeTypeName("Display *")] UIntPtr dpy, [NativeTypeName("Colormap")] UIntPtr colormap, [NativeTypeName("XcmsColor *")] XcmsColor* pColor_in);
 
-        [DllImport(libraryPath, EntryPoint = "XcmsStoreColors", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XcmsStoreColors", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XcmsStoreColors([NativeTypeName("Display *")] UIntPtr dpy, [NativeTypeName("Colormap")] UIntPtr colormap, [NativeTypeName("XcmsColor *")] XcmsColor* colorArry_in, [NativeTypeName("unsigned int")] uint nColors, [NativeTypeName("int *")] int* compArry_return);
 
-        [DllImport(libraryPath, EntryPoint = "XcmsTekHVCClipC", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XcmsTekHVCClipC", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XcmsTekHVCClipC([NativeTypeName("XcmsCCC")] XcmsCCC* ccc, [NativeTypeName("XcmsColor *")] XcmsColor* colors_in_out, [NativeTypeName("unsigned int")] uint ncolors, [NativeTypeName("unsigned int")] uint index, [NativeTypeName("int *")] int* compression_flags_return);
 
-        [DllImport(libraryPath, EntryPoint = "XcmsTekHVCClipV", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XcmsTekHVCClipV", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XcmsTekHVCClipV([NativeTypeName("XcmsCCC")] XcmsCCC* ccc, [NativeTypeName("XcmsColor *")] XcmsColor* colors_in_out, [NativeTypeName("unsigned int")] uint ncolors, [NativeTypeName("unsigned int")] uint index, [NativeTypeName("int *")] int* compression_flags_return);
 
-        [DllImport(libraryPath, EntryPoint = "XcmsTekHVCClipVC", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XcmsTekHVCClipVC", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XcmsTekHVCClipVC([NativeTypeName("XcmsCCC")] XcmsCCC* ccc, [NativeTypeName("XcmsColor *")] XcmsColor* colors_in_out, [NativeTypeName("unsigned int")] uint ncolors, [NativeTypeName("unsigned int")] uint index, [NativeTypeName("int *")] int* compression_flags_return);
 
-        [DllImport(libraryPath, EntryPoint = "XcmsTekHVCQueryMaxC", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XcmsTekHVCQueryMaxC", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XcmsTekHVCQueryMaxC([NativeTypeName("XcmsCCC")] XcmsCCC* ccc, [NativeTypeName("XcmsFloat")] double hue, [NativeTypeName("XcmsFloat")] double value, [NativeTypeName("XcmsColor *")] XcmsColor* color_return);
 
-        [DllImport(libraryPath, EntryPoint = "XcmsTekHVCQueryMaxV", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XcmsTekHVCQueryMaxV", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XcmsTekHVCQueryMaxV([NativeTypeName("XcmsCCC")] XcmsCCC* ccc, [NativeTypeName("XcmsFloat")] double hue, [NativeTypeName("XcmsFloat")] double chroma, [NativeTypeName("XcmsColor *")] XcmsColor* color_return);
 
-        [DllImport(libraryPath, EntryPoint = "XcmsTekHVCQueryMaxVC", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XcmsTekHVCQueryMaxVC", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XcmsTekHVCQueryMaxVC([NativeTypeName("XcmsCCC")] XcmsCCC* ccc, [NativeTypeName("XcmsFloat")] double hue, [NativeTypeName("XcmsColor *")] XcmsColor* color_return);
 
-        [DllImport(libraryPath, EntryPoint = "XcmsTekHVCQueryMaxVSamples", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XcmsTekHVCQueryMaxVSamples", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XcmsTekHVCQueryMaxVSamples([NativeTypeName("XcmsCCC")] XcmsCCC* ccc, [NativeTypeName("XcmsFloat")] double hue, [NativeTypeName("XcmsColor *")] XcmsColor* colors_return, [NativeTypeName("unsigned int")] uint nsamples);
 
-        [DllImport(libraryPath, EntryPoint = "XcmsTekHVCQueryMinV", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XcmsTekHVCQueryMinV", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XcmsTekHVCQueryMinV([NativeTypeName("XcmsCCC")] XcmsCCC* ccc, [NativeTypeName("XcmsFloat")] double hue, [NativeTypeName("XcmsFloat")] double chroma, [NativeTypeName("XcmsColor *")] XcmsColor* color_return);
 
-        [DllImport(libraryPath, EntryPoint = "XcmsTekHVCToCIEuvY", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XcmsTekHVCToCIEuvY", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XcmsTekHVCToCIEuvY([NativeTypeName("XcmsCCC")] XcmsCCC* ccc, [NativeTypeName("XcmsColor *")] XcmsColor* white_point, [NativeTypeName("XcmsColor *")] XcmsColor* colors, [NativeTypeName("unsigned int")] uint ncolors);
 
-        [DllImport(libraryPath, EntryPoint = "XcmsTekHVCWhiteShiftColors", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XcmsTekHVCWhiteShiftColors", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XcmsTekHVCWhiteShiftColors([NativeTypeName("XcmsCCC")] XcmsCCC* ccc, [NativeTypeName("XcmsColor *")] XcmsColor* initial_white_point, [NativeTypeName("XcmsColor *")] XcmsColor* target_white_point, [NativeTypeName("XcmsColorFormat")] UIntPtr target_format, [NativeTypeName("XcmsColor *")] XcmsColor* colors_in_out, [NativeTypeName("unsigned int")] uint ncolors, [NativeTypeName("int *")] int* compression_flags_return);
 
-        [DllImport(libraryPath, EntryPoint = "XcmsVisualOfCCC", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XcmsVisualOfCCC", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("Visual *")]
         public static extern Visual* XcmsVisualOfCCC([NativeTypeName("XcmsCCC")] XcmsCCC* ccc);
     }

--- a/sources/Interop/Xlib/Xlib/Xlib.cs
+++ b/sources/Interop/Xlib/Xlib/Xlib.cs
@@ -10,1351 +10,1351 @@ namespace TerraFX.Interop
 {
     public static unsafe partial class Xlib
     {
-        [DllImport(libraryPath, EntryPoint = "_Xmblen", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "_Xmblen", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int _Xmblen([NativeTypeName("char *")] sbyte* str, int len);
 
         // public static extern int _Xdebug;
 
-        [DllImport(libraryPath, EntryPoint = "XLoadQueryFont", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XLoadQueryFont", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("XFontStruct *")]
         public static extern XFontStruct* XLoadQueryFont([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("const char *")] sbyte* name);
 
-        [DllImport(libraryPath, EntryPoint = "XQueryFont", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XQueryFont", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("XFontStruct *")]
         public static extern XFontStruct* XQueryFont([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("XID")] UIntPtr font_ID);
 
-        [DllImport(libraryPath, EntryPoint = "XGetMotionEvents", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XGetMotionEvents", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("XTimeCoord *")]
         public static extern XTimeCoord* XGetMotionEvents([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Window")] UIntPtr w, [NativeTypeName("Time")] UIntPtr start, [NativeTypeName("Time")] UIntPtr stop, [NativeTypeName("int *")] int* nevents_return);
 
-        [DllImport(libraryPath, EntryPoint = "XDeleteModifiermapEntry", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XDeleteModifiermapEntry", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("XModifierKeymap *")]
         public static extern XModifierKeymap* XDeleteModifiermapEntry([NativeTypeName("XModifierKeymap *")] XModifierKeymap* modmap, [NativeTypeName("KeyCode")] byte keycode_entry, int modifier);
 
-        [DllImport(libraryPath, EntryPoint = "XGetModifierMapping", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XGetModifierMapping", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("XModifierKeymap *")]
         public static extern XModifierKeymap* XGetModifierMapping([NativeTypeName("Display *")] UIntPtr display);
 
-        [DllImport(libraryPath, EntryPoint = "XInsertModifiermapEntry", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XInsertModifiermapEntry", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("XModifierKeymap *")]
         public static extern XModifierKeymap* XInsertModifiermapEntry([NativeTypeName("XModifierKeymap *")] XModifierKeymap* modmap, [NativeTypeName("KeyCode")] byte keycode_entry, int modifier);
 
-        [DllImport(libraryPath, EntryPoint = "XNewModifiermap", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XNewModifiermap", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("XModifierKeymap *")]
         public static extern XModifierKeymap* XNewModifiermap(int max_keys_per_mod);
 
-        [DllImport(libraryPath, EntryPoint = "XCreateImage", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XCreateImage", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("XImage *")]
         public static extern XImage* XCreateImage([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Visual *")] Visual* visual, [NativeTypeName("unsigned int")] uint depth, int format, int offset, [NativeTypeName("char *")] sbyte* data, [NativeTypeName("unsigned int")] uint width, [NativeTypeName("unsigned int")] uint height, int bitmap_pad, int bytes_per_line);
 
-        [DllImport(libraryPath, EntryPoint = "XInitImage", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XInitImage", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XInitImage([NativeTypeName("XImage *")] XImage* image);
 
-        [DllImport(libraryPath, EntryPoint = "XGetImage", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XGetImage", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("XImage *")]
         public static extern XImage* XGetImage([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Drawable")] UIntPtr d, int x, int y, [NativeTypeName("unsigned int")] uint width, [NativeTypeName("unsigned int")] uint height, [NativeTypeName("unsigned long")] UIntPtr plane_mask, int format);
 
-        [DllImport(libraryPath, EntryPoint = "XGetSubImage", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XGetSubImage", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("XImage *")]
         public static extern XImage* XGetSubImage([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Drawable")] UIntPtr d, int x, int y, [NativeTypeName("unsigned int")] uint width, [NativeTypeName("unsigned int")] uint height, [NativeTypeName("unsigned long")] UIntPtr plane_mask, int format, [NativeTypeName("XImage *")] XImage* dest_image, int dest_x, int dest_y);
 
-        [DllImport(libraryPath, EntryPoint = "XOpenDisplay", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XOpenDisplay", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("Display *")]
         public static extern UIntPtr XOpenDisplay([NativeTypeName("const char *")] sbyte* display_name);
 
-        [DllImport(libraryPath, EntryPoint = "XrmInitialize", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XrmInitialize", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void XrmInitialize();
 
-        [DllImport(libraryPath, EntryPoint = "XFetchBytes", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XFetchBytes", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("char *")]
         public static extern sbyte* XFetchBytes([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("int *")] int* nbytes_return);
 
-        [DllImport(libraryPath, EntryPoint = "XFetchBuffer", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XFetchBuffer", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("char *")]
         public static extern sbyte* XFetchBuffer([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("int *")] int* nbytes_return, int buffer);
 
-        [DllImport(libraryPath, EntryPoint = "XGetAtomName", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XGetAtomName", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("char *")]
         public static extern sbyte* XGetAtomName([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Atom")] UIntPtr atom);
 
-        [DllImport(libraryPath, EntryPoint = "XGetAtomNames", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XGetAtomNames", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XGetAtomNames([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Atom *")] UIntPtr* atoms, int count, [NativeTypeName("char **")] sbyte** names_return);
 
-        [DllImport(libraryPath, EntryPoint = "XGetDefault", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XGetDefault", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("char *")]
         public static extern sbyte* XGetDefault([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("const char *")] sbyte* program, [NativeTypeName("const char *")] sbyte* option);
 
-        [DllImport(libraryPath, EntryPoint = "XDisplayName", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XDisplayName", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("char *")]
         public static extern sbyte* XDisplayName([NativeTypeName("const char *")] sbyte* c_string);
 
-        [DllImport(libraryPath, EntryPoint = "XKeysymToString", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XKeysymToString", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("char *")]
         public static extern sbyte* XKeysymToString([NativeTypeName("KeySym")] UIntPtr keysym);
 
-        [DllImport(libraryPath, EntryPoint = "XSynchronize", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XSynchronize", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("int (*)(Display *)")]
         public static extern IntPtr XSynchronize([NativeTypeName("Display *")] UIntPtr display, int onoff);
 
-        [DllImport(libraryPath, EntryPoint = "XSetAfterFunction", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XSetAfterFunction", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("int (*)(Display *)")]
         public static extern IntPtr XSetAfterFunction([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("int (*)(Display *)")] IntPtr procedure);
 
-        [DllImport(libraryPath, EntryPoint = "XInternAtom", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XInternAtom", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("Atom")]
         public static extern UIntPtr XInternAtom([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("const char *")] sbyte* atom_name, int only_if_exists);
 
-        [DllImport(libraryPath, EntryPoint = "XInternAtoms", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XInternAtoms", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XInternAtoms([NativeTypeName("Display *")] UIntPtr dpy, [NativeTypeName("char **")] sbyte** names, int count, int onlyIfExists, [NativeTypeName("Atom *")] UIntPtr* atoms_return);
 
-        [DllImport(libraryPath, EntryPoint = "XCopyColormapAndFree", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XCopyColormapAndFree", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("Colormap")]
         public static extern UIntPtr XCopyColormapAndFree([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Colormap")] UIntPtr colormap);
 
-        [DllImport(libraryPath, EntryPoint = "XCreateColormap", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XCreateColormap", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("Colormap")]
         public static extern UIntPtr XCreateColormap([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Window")] UIntPtr w, [NativeTypeName("Visual *")] Visual* visual, int alloc);
 
-        [DllImport(libraryPath, EntryPoint = "XCreatePixmapCursor", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XCreatePixmapCursor", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("Cursor")]
         public static extern UIntPtr XCreatePixmapCursor([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Pixmap")] UIntPtr source, [NativeTypeName("Pixmap")] UIntPtr mask, [NativeTypeName("XColor *")] XColor* foreground_color, [NativeTypeName("XColor *")] XColor* background_color, [NativeTypeName("unsigned int")] uint x, [NativeTypeName("unsigned int")] uint y);
 
-        [DllImport(libraryPath, EntryPoint = "XCreateGlyphCursor", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XCreateGlyphCursor", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("Cursor")]
         public static extern UIntPtr XCreateGlyphCursor([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Font")] UIntPtr source_font, [NativeTypeName("Font")] UIntPtr mask_font, [NativeTypeName("unsigned int")] uint source_char, [NativeTypeName("unsigned int")] uint mask_char, [NativeTypeName("const XColor *")] XColor* foreground_color, [NativeTypeName("const XColor *")] XColor* background_color);
 
-        [DllImport(libraryPath, EntryPoint = "XCreateFontCursor", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XCreateFontCursor", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("Cursor")]
         public static extern UIntPtr XCreateFontCursor([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("unsigned int")] uint shape);
 
-        [DllImport(libraryPath, EntryPoint = "XLoadFont", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XLoadFont", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("Font")]
         public static extern UIntPtr XLoadFont([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("const char *")] sbyte* name);
 
-        [DllImport(libraryPath, EntryPoint = "XCreateGC", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XCreateGC", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("GC")]
         public static extern XGC* XCreateGC([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Drawable")] UIntPtr d, [NativeTypeName("unsigned long")] UIntPtr valuemask, [NativeTypeName("XGCValues *")] XGCValues* values);
 
-        [DllImport(libraryPath, EntryPoint = "XGContextFromGC", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XGContextFromGC", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("GContext")]
         public static extern UIntPtr XGContextFromGC([NativeTypeName("GC")] XGC* gc);
 
-        [DllImport(libraryPath, EntryPoint = "XFlushGC", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XFlushGC", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void XFlushGC([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("GC")] XGC* gc);
 
-        [DllImport(libraryPath, EntryPoint = "XCreatePixmap", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XCreatePixmap", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("Pixmap")]
         public static extern UIntPtr XCreatePixmap([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Drawable")] UIntPtr d, [NativeTypeName("unsigned int")] uint width, [NativeTypeName("unsigned int")] uint height, [NativeTypeName("unsigned int")] uint depth);
 
-        [DllImport(libraryPath, EntryPoint = "XCreateBitmapFromData", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XCreateBitmapFromData", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("Pixmap")]
         public static extern UIntPtr XCreateBitmapFromData([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Drawable")] UIntPtr d, [NativeTypeName("const char *")] sbyte* data, [NativeTypeName("unsigned int")] uint width, [NativeTypeName("unsigned int")] uint height);
 
-        [DllImport(libraryPath, EntryPoint = "XCreatePixmapFromBitmapData", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XCreatePixmapFromBitmapData", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("Pixmap")]
         public static extern UIntPtr XCreatePixmapFromBitmapData([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Drawable")] UIntPtr d, [NativeTypeName("char *")] sbyte* data, [NativeTypeName("unsigned int")] uint width, [NativeTypeName("unsigned int")] uint height, [NativeTypeName("unsigned long")] UIntPtr fg, [NativeTypeName("unsigned long")] UIntPtr bg, [NativeTypeName("unsigned int")] uint depth);
 
-        [DllImport(libraryPath, EntryPoint = "XCreateSimpleWindow", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XCreateSimpleWindow", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("Window")]
         public static extern UIntPtr XCreateSimpleWindow([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Window")] UIntPtr parent, int x, int y, [NativeTypeName("unsigned int")] uint width, [NativeTypeName("unsigned int")] uint height, [NativeTypeName("unsigned int")] uint border_width, [NativeTypeName("unsigned long")] UIntPtr border, [NativeTypeName("unsigned long")] UIntPtr background);
 
-        [DllImport(libraryPath, EntryPoint = "XGetSelectionOwner", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XGetSelectionOwner", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("Window")]
         public static extern UIntPtr XGetSelectionOwner([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Atom")] UIntPtr selection);
 
-        [DllImport(libraryPath, EntryPoint = "XCreateWindow", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XCreateWindow", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("Window")]
         public static extern UIntPtr XCreateWindow([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Window")] UIntPtr parent, int x, int y, [NativeTypeName("unsigned int")] uint width, [NativeTypeName("unsigned int")] uint height, [NativeTypeName("unsigned int")] uint border_width, int depth, [NativeTypeName("unsigned int")] uint c_class, [NativeTypeName("Visual *")] Visual* visual, [NativeTypeName("unsigned long")] UIntPtr valuemask, [NativeTypeName("XSetWindowAttributes *")] XSetWindowAttributes* attributes);
 
-        [DllImport(libraryPath, EntryPoint = "XListInstalledColormaps", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XListInstalledColormaps", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("Colormap *")]
         public static extern UIntPtr* XListInstalledColormaps([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Window")] UIntPtr w, [NativeTypeName("int *")] int* num_return);
 
-        [DllImport(libraryPath, EntryPoint = "XListFonts", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XListFonts", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("char **")]
         public static extern sbyte** XListFonts([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("const char *")] sbyte* pattern, int maxnames, [NativeTypeName("int *")] int* actual_count_return);
 
-        [DllImport(libraryPath, EntryPoint = "XListFontsWithInfo", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XListFontsWithInfo", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("char **")]
         public static extern sbyte** XListFontsWithInfo([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("const char *")] sbyte* pattern, int maxnames, [NativeTypeName("int *")] int* count_return, [NativeTypeName("XFontStruct **")] XFontStruct** info_return);
 
-        [DllImport(libraryPath, EntryPoint = "XGetFontPath", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XGetFontPath", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("char **")]
         public static extern sbyte** XGetFontPath([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("int *")] int* npaths_return);
 
-        [DllImport(libraryPath, EntryPoint = "XListExtensions", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XListExtensions", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("char **")]
         public static extern sbyte** XListExtensions([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("int *")] int* nextensions_return);
 
-        [DllImport(libraryPath, EntryPoint = "XListProperties", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XListProperties", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("Atom *")]
         public static extern UIntPtr* XListProperties([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Window")] UIntPtr w, [NativeTypeName("int *")] int* num_prop_Return);
 
-        [DllImport(libraryPath, EntryPoint = "XListHosts", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XListHosts", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("XHostAddress *")]
         public static extern XHostAddress* XListHosts([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("int *")] int* nhosts_return, [NativeTypeName("int *")] int* state_return);
 
-        [DllImport(libraryPath, EntryPoint = "XKeycodeToKeysym", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XKeycodeToKeysym", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("KeySym")]
         public static extern UIntPtr XKeycodeToKeysym([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("KeyCode")] byte keycode, int index);
 
-        [DllImport(libraryPath, EntryPoint = "XLookupKeysym", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XLookupKeysym", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("KeySym")]
         public static extern UIntPtr XLookupKeysym([NativeTypeName("XKeyEvent *")] XKeyEvent* key_event, int index);
 
-        [DllImport(libraryPath, EntryPoint = "XGetKeyboardMapping", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XGetKeyboardMapping", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("KeySym *")]
         public static extern UIntPtr* XGetKeyboardMapping([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("KeyCode")] byte first_keycode, int keycode_count, [NativeTypeName("int *")] int* keysyms_per_keycode_return);
 
-        [DllImport(libraryPath, EntryPoint = "XStringToKeysym", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XStringToKeysym", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("KeySym")]
         public static extern UIntPtr XStringToKeysym([NativeTypeName("const char *")] sbyte* c_string);
 
-        [DllImport(libraryPath, EntryPoint = "XMaxRequestSize", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XMaxRequestSize", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("long")]
         public static extern IntPtr XMaxRequestSize([NativeTypeName("Display *")] UIntPtr display);
 
-        [DllImport(libraryPath, EntryPoint = "XExtendedMaxRequestSize", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XExtendedMaxRequestSize", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("long")]
         public static extern IntPtr XExtendedMaxRequestSize([NativeTypeName("Display *")] UIntPtr display);
 
-        [DllImport(libraryPath, EntryPoint = "XResourceManagerString", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XResourceManagerString", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("char *")]
         public static extern sbyte* XResourceManagerString([NativeTypeName("Display *")] UIntPtr display);
 
-        [DllImport(libraryPath, EntryPoint = "XScreenResourceString", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XScreenResourceString", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("char *")]
         public static extern sbyte* XScreenResourceString([NativeTypeName("Screen *")] Screen* screen);
 
-        [DllImport(libraryPath, EntryPoint = "XDisplayMotionBufferSize", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XDisplayMotionBufferSize", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("unsigned long")]
         public static extern UIntPtr XDisplayMotionBufferSize([NativeTypeName("Display *")] UIntPtr display);
 
-        [DllImport(libraryPath, EntryPoint = "XVisualIDFromVisual", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XVisualIDFromVisual", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("VisualID")]
         public static extern UIntPtr XVisualIDFromVisual([NativeTypeName("Visual *")] Visual* visual);
 
-        [DllImport(libraryPath, EntryPoint = "XInitThreads", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XInitThreads", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XInitThreads();
 
-        [DllImport(libraryPath, EntryPoint = "XLockDisplay", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XLockDisplay", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void XLockDisplay([NativeTypeName("Display *")] UIntPtr display);
 
-        [DllImport(libraryPath, EntryPoint = "XUnlockDisplay", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XUnlockDisplay", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void XUnlockDisplay([NativeTypeName("Display *")] UIntPtr display);
 
-        [DllImport(libraryPath, EntryPoint = "XInitExtension", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XInitExtension", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("XExtCodes *")]
         public static extern XExtCodes* XInitExtension([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("const char *")] sbyte* name);
 
-        [DllImport(libraryPath, EntryPoint = "XAddExtension", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XAddExtension", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("XExtCodes *")]
         public static extern XExtCodes* XAddExtension([NativeTypeName("Display *")] UIntPtr display);
 
-        [DllImport(libraryPath, EntryPoint = "XFindOnExtensionList", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XFindOnExtensionList", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("XExtData *")]
         public static extern XExtData* XFindOnExtensionList([NativeTypeName("XExtData **")] XExtData** structure, int number);
 
-        [DllImport(libraryPath, EntryPoint = "XEHeadOfExtensionList", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XEHeadOfExtensionList", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("XExtData **")]
         public static extern XExtData** XEHeadOfExtensionList(XEDataObject c_object);
 
-        [DllImport(libraryPath, EntryPoint = "XRootWindow", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XRootWindow", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("Window")]
         public static extern UIntPtr XRootWindow([NativeTypeName("Display *")] UIntPtr display, int screen_number);
 
-        [DllImport(libraryPath, EntryPoint = "XDefaultRootWindow", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XDefaultRootWindow", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("Window")]
         public static extern UIntPtr XDefaultRootWindow([NativeTypeName("Display *")] UIntPtr display);
 
-        [DllImport(libraryPath, EntryPoint = "XRootWindowOfScreen", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XRootWindowOfScreen", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("Window")]
         public static extern UIntPtr XRootWindowOfScreen([NativeTypeName("Screen *")] Screen* screen);
 
-        [DllImport(libraryPath, EntryPoint = "XDefaultVisual", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XDefaultVisual", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("Visual *")]
         public static extern Visual* XDefaultVisual([NativeTypeName("Display *")] UIntPtr display, int screen_number);
 
-        [DllImport(libraryPath, EntryPoint = "XDefaultVisualOfScreen", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XDefaultVisualOfScreen", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("Visual *")]
         public static extern Visual* XDefaultVisualOfScreen([NativeTypeName("Screen *")] Screen* screen);
 
-        [DllImport(libraryPath, EntryPoint = "XDefaultGC", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XDefaultGC", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("GC")]
         public static extern XGC* XDefaultGC([NativeTypeName("Display *")] UIntPtr display, int screen_number);
 
-        [DllImport(libraryPath, EntryPoint = "XDefaultGCOfScreen", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XDefaultGCOfScreen", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("GC")]
         public static extern XGC* XDefaultGCOfScreen([NativeTypeName("Screen *")] Screen* screen);
 
-        [DllImport(libraryPath, EntryPoint = "XBlackPixel", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XBlackPixel", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("unsigned long")]
         public static extern UIntPtr XBlackPixel([NativeTypeName("Display *")] UIntPtr display, int screen_number);
 
-        [DllImport(libraryPath, EntryPoint = "XWhitePixel", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XWhitePixel", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("unsigned long")]
         public static extern UIntPtr XWhitePixel([NativeTypeName("Display *")] UIntPtr display, int screen_number);
 
-        [DllImport(libraryPath, EntryPoint = "XAllPlanes", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XAllPlanes", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("unsigned long")]
         public static extern UIntPtr XAllPlanes();
 
-        [DllImport(libraryPath, EntryPoint = "XBlackPixelOfScreen", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XBlackPixelOfScreen", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("unsigned long")]
         public static extern UIntPtr XBlackPixelOfScreen([NativeTypeName("Screen *")] Screen* screen);
 
-        [DllImport(libraryPath, EntryPoint = "XWhitePixelOfScreen", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XWhitePixelOfScreen", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("unsigned long")]
         public static extern UIntPtr XWhitePixelOfScreen([NativeTypeName("Screen *")] Screen* screen);
 
-        [DllImport(libraryPath, EntryPoint = "XNextRequest", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XNextRequest", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("unsigned long")]
         public static extern UIntPtr XNextRequest([NativeTypeName("Display *")] UIntPtr display);
 
-        [DllImport(libraryPath, EntryPoint = "XLastKnownRequestProcessed", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XLastKnownRequestProcessed", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("unsigned long")]
         public static extern UIntPtr XLastKnownRequestProcessed([NativeTypeName("Display *")] UIntPtr display);
 
-        [DllImport(libraryPath, EntryPoint = "XServerVendor", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XServerVendor", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("char *")]
         public static extern sbyte* XServerVendor([NativeTypeName("Display *")] UIntPtr display);
 
-        [DllImport(libraryPath, EntryPoint = "XDisplayString", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XDisplayString", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("char *")]
         public static extern sbyte* XDisplayString([NativeTypeName("Display *")] UIntPtr display);
 
-        [DllImport(libraryPath, EntryPoint = "XDefaultColormap", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XDefaultColormap", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("Colormap")]
         public static extern UIntPtr XDefaultColormap([NativeTypeName("Display *")] UIntPtr display, int screen_number);
 
-        [DllImport(libraryPath, EntryPoint = "XDefaultColormapOfScreen", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XDefaultColormapOfScreen", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("Colormap")]
         public static extern UIntPtr XDefaultColormapOfScreen([NativeTypeName("Screen *")] Screen* screen);
 
-        [DllImport(libraryPath, EntryPoint = "XDisplayOfScreen", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XDisplayOfScreen", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("Display *")]
         public static extern UIntPtr XDisplayOfScreen([NativeTypeName("Screen *")] Screen* screen);
 
-        [DllImport(libraryPath, EntryPoint = "XScreenOfDisplay", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XScreenOfDisplay", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("Screen *")]
         public static extern Screen* XScreenOfDisplay([NativeTypeName("Display *")] UIntPtr display, int screen_number);
 
-        [DllImport(libraryPath, EntryPoint = "XDefaultScreenOfDisplay", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XDefaultScreenOfDisplay", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("Screen *")]
         public static extern Screen* XDefaultScreenOfDisplay([NativeTypeName("Display *")] UIntPtr display);
 
-        [DllImport(libraryPath, EntryPoint = "XEventMaskOfScreen", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XEventMaskOfScreen", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("long")]
         public static extern IntPtr XEventMaskOfScreen([NativeTypeName("Screen *")] Screen* screen);
 
-        [DllImport(libraryPath, EntryPoint = "XScreenNumberOfScreen", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XScreenNumberOfScreen", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XScreenNumberOfScreen([NativeTypeName("Screen *")] Screen* screen);
 
-        [DllImport(libraryPath, EntryPoint = "XSetErrorHandler", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XSetErrorHandler", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("XErrorHandler")]
         public static extern IntPtr XSetErrorHandler([NativeTypeName("XErrorHandler")] IntPtr handler);
 
-        [DllImport(libraryPath, EntryPoint = "XSetIOErrorHandler", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XSetIOErrorHandler", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("XIOErrorHandler")]
         public static extern IntPtr XSetIOErrorHandler([NativeTypeName("XIOErrorHandler")] IntPtr handler);
 
-        [DllImport(libraryPath, EntryPoint = "XListPixmapFormats", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XListPixmapFormats", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("XPixmapFormatValues *")]
         public static extern XPixmapFormatValues* XListPixmapFormats([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("int *")] int* count_return);
 
-        [DllImport(libraryPath, EntryPoint = "XListDepths", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XListDepths", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("int *")]
         public static extern int* XListDepths([NativeTypeName("Display *")] UIntPtr display, int screen_number, [NativeTypeName("int *")] int* count_return);
 
-        [DllImport(libraryPath, EntryPoint = "XReconfigureWMWindow", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XReconfigureWMWindow", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XReconfigureWMWindow([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Window")] UIntPtr w, int screen_number, [NativeTypeName("unsigned int")] uint mask, [NativeTypeName("XWindowChanges *")] XWindowChanges* changes);
 
-        [DllImport(libraryPath, EntryPoint = "XGetWMProtocols", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XGetWMProtocols", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XGetWMProtocols([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Window")] UIntPtr w, [NativeTypeName("Atom **")] UIntPtr** protocols_return, [NativeTypeName("int *")] int* count_return);
 
-        [DllImport(libraryPath, EntryPoint = "XSetWMProtocols", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XSetWMProtocols", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XSetWMProtocols([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Window")] UIntPtr w, [NativeTypeName("Atom *")] UIntPtr* protocols, int count);
 
-        [DllImport(libraryPath, EntryPoint = "XIconifyWindow", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XIconifyWindow", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XIconifyWindow([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Window")] UIntPtr w, int screen_number);
 
-        [DllImport(libraryPath, EntryPoint = "XWithdrawWindow", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XWithdrawWindow", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XWithdrawWindow([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Window")] UIntPtr w, int screen_number);
 
-        [DllImport(libraryPath, EntryPoint = "XGetCommand", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XGetCommand", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XGetCommand([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Window")] UIntPtr w, [NativeTypeName("char ***")] sbyte*** argv_return, [NativeTypeName("int *")] int* argc_return);
 
-        [DllImport(libraryPath, EntryPoint = "XGetWMColormapWindows", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XGetWMColormapWindows", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XGetWMColormapWindows([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Window")] UIntPtr w, [NativeTypeName("Window **")] UIntPtr** windows_return, [NativeTypeName("int *")] int* count_return);
 
-        [DllImport(libraryPath, EntryPoint = "XSetWMColormapWindows", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XSetWMColormapWindows", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XSetWMColormapWindows([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Window")] UIntPtr w, [NativeTypeName("Window *")] UIntPtr* colormap_windows, int count);
 
-        [DllImport(libraryPath, EntryPoint = "XFreeStringList", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XFreeStringList", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void XFreeStringList([NativeTypeName("char **")] sbyte** list);
 
-        [DllImport(libraryPath, EntryPoint = "XSetTransientForHint", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XSetTransientForHint", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XSetTransientForHint([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Window")] UIntPtr w, [NativeTypeName("Window")] UIntPtr prop_window);
 
-        [DllImport(libraryPath, EntryPoint = "XActivateScreenSaver", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XActivateScreenSaver", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XActivateScreenSaver([NativeTypeName("Display *")] UIntPtr display);
 
-        [DllImport(libraryPath, EntryPoint = "XAddHost", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XAddHost", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XAddHost([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("XHostAddress *")] XHostAddress* host);
 
-        [DllImport(libraryPath, EntryPoint = "XAddHosts", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XAddHosts", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XAddHosts([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("XHostAddress *")] XHostAddress* hosts, int num_hosts);
 
-        [DllImport(libraryPath, EntryPoint = "XAddToExtensionList", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XAddToExtensionList", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XAddToExtensionList([NativeTypeName("struct XExtData **")] XExtData** structure, [NativeTypeName("XExtData *")] XExtData* ext_data);
 
-        [DllImport(libraryPath, EntryPoint = "XAddToSaveSet", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XAddToSaveSet", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XAddToSaveSet([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Window")] UIntPtr w);
 
-        [DllImport(libraryPath, EntryPoint = "XAllocColor", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XAllocColor", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XAllocColor([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Colormap")] UIntPtr colormap, [NativeTypeName("XColor *")] XColor* screen_in_out);
 
-        [DllImport(libraryPath, EntryPoint = "XAllocColorCells", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XAllocColorCells", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XAllocColorCells([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Colormap")] UIntPtr colormap, int contig, [NativeTypeName("unsigned long *")] UIntPtr* plane_masks_return, [NativeTypeName("unsigned int")] uint nplanes, [NativeTypeName("unsigned long *")] UIntPtr* pixels_return, [NativeTypeName("unsigned int")] uint npixels);
 
-        [DllImport(libraryPath, EntryPoint = "XAllocColorPlanes", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XAllocColorPlanes", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XAllocColorPlanes([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Colormap")] UIntPtr colormap, int contig, [NativeTypeName("unsigned long *")] UIntPtr* pixels_return, int ncolors, int nreds, int ngreens, int nblues, [NativeTypeName("unsigned long *")] UIntPtr* rmask_return, [NativeTypeName("unsigned long *")] UIntPtr* gmask_return, [NativeTypeName("unsigned long *")] UIntPtr* bmask_return);
 
-        [DllImport(libraryPath, EntryPoint = "XAllocNamedColor", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XAllocNamedColor", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XAllocNamedColor([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Colormap")] UIntPtr colormap, [NativeTypeName("const char *")] sbyte* color_name, [NativeTypeName("XColor *")] XColor* screen_def_return, [NativeTypeName("XColor *")] XColor* exact_def_return);
 
-        [DllImport(libraryPath, EntryPoint = "XAllowEvents", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XAllowEvents", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XAllowEvents([NativeTypeName("Display *")] UIntPtr display, int event_mode, [NativeTypeName("Time")] UIntPtr time);
 
-        [DllImport(libraryPath, EntryPoint = "XAutoRepeatOff", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XAutoRepeatOff", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XAutoRepeatOff([NativeTypeName("Display *")] UIntPtr display);
 
-        [DllImport(libraryPath, EntryPoint = "XAutoRepeatOn", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XAutoRepeatOn", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XAutoRepeatOn([NativeTypeName("Display *")] UIntPtr display);
 
-        [DllImport(libraryPath, EntryPoint = "XBell", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XBell", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XBell([NativeTypeName("Display *")] UIntPtr display, int percent);
 
-        [DllImport(libraryPath, EntryPoint = "XBitmapBitOrder", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XBitmapBitOrder", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XBitmapBitOrder([NativeTypeName("Display *")] UIntPtr display);
 
-        [DllImport(libraryPath, EntryPoint = "XBitmapPad", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XBitmapPad", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XBitmapPad([NativeTypeName("Display *")] UIntPtr display);
 
-        [DllImport(libraryPath, EntryPoint = "XBitmapUnit", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XBitmapUnit", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XBitmapUnit([NativeTypeName("Display *")] UIntPtr display);
 
-        [DllImport(libraryPath, EntryPoint = "XCellsOfScreen", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XCellsOfScreen", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XCellsOfScreen([NativeTypeName("Screen *")] Screen* screen);
 
-        [DllImport(libraryPath, EntryPoint = "XChangeActivePointerGrab", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XChangeActivePointerGrab", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XChangeActivePointerGrab([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("unsigned int")] uint event_mask, [NativeTypeName("Cursor")] UIntPtr cursor, [NativeTypeName("Time")] UIntPtr time);
 
-        [DllImport(libraryPath, EntryPoint = "XChangeGC", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XChangeGC", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XChangeGC([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("GC")] XGC* gc, [NativeTypeName("unsigned long")] UIntPtr valuemask, [NativeTypeName("XGCValues *")] XGCValues* values);
 
-        [DllImport(libraryPath, EntryPoint = "XChangeKeyboardControl", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XChangeKeyboardControl", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XChangeKeyboardControl([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("unsigned long")] UIntPtr value_mask, [NativeTypeName("XKeyboardControl *")] XKeyboardControl* values);
 
-        [DllImport(libraryPath, EntryPoint = "XChangeKeyboardMapping", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XChangeKeyboardMapping", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XChangeKeyboardMapping([NativeTypeName("Display *")] UIntPtr display, int first_keycode, int keysyms_per_keycode, [NativeTypeName("KeySym *")] UIntPtr* keysyms, int num_codes);
 
-        [DllImport(libraryPath, EntryPoint = "XChangePointerControl", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XChangePointerControl", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XChangePointerControl([NativeTypeName("Display *")] UIntPtr display, int do_accel, int do_threshold, int accel_numerator, int accel_denominator, int threshold);
 
-        [DllImport(libraryPath, EntryPoint = "XChangeProperty", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XChangeProperty", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XChangeProperty([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Window")] UIntPtr w, [NativeTypeName("Atom")] UIntPtr property, [NativeTypeName("Atom")] UIntPtr type, int format, int mode, [NativeTypeName("const unsigned char *")] byte* data, int nelements);
 
-        [DllImport(libraryPath, EntryPoint = "XChangeSaveSet", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XChangeSaveSet", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XChangeSaveSet([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Window")] UIntPtr w, int change_mode);
 
-        [DllImport(libraryPath, EntryPoint = "XChangeWindowAttributes", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XChangeWindowAttributes", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XChangeWindowAttributes([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Window")] UIntPtr w, [NativeTypeName("unsigned long")] UIntPtr valuemask, [NativeTypeName("XSetWindowAttributes *")] XSetWindowAttributes* attributes);
 
-        [DllImport(libraryPath, EntryPoint = "XCheckIfEvent", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XCheckIfEvent", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XCheckIfEvent([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("XEvent *")] XEvent* event_return, [NativeTypeName("int (*)(Display *, XEvent *, XPointer)")] IntPtr predicate, [NativeTypeName("XPointer")] sbyte* arg);
 
-        [DllImport(libraryPath, EntryPoint = "XCheckMaskEvent", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XCheckMaskEvent", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XCheckMaskEvent([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("long")] IntPtr event_mask, [NativeTypeName("XEvent *")] XEvent* event_return);
 
-        [DllImport(libraryPath, EntryPoint = "XCheckTypedEvent", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XCheckTypedEvent", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XCheckTypedEvent([NativeTypeName("Display *")] UIntPtr display, int event_type, [NativeTypeName("XEvent *")] XEvent* event_return);
 
-        [DllImport(libraryPath, EntryPoint = "XCheckTypedWindowEvent", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XCheckTypedWindowEvent", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XCheckTypedWindowEvent([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Window")] UIntPtr w, int event_type, [NativeTypeName("XEvent *")] XEvent* event_return);
 
-        [DllImport(libraryPath, EntryPoint = "XCheckWindowEvent", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XCheckWindowEvent", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XCheckWindowEvent([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Window")] UIntPtr w, [NativeTypeName("long")] IntPtr event_mask, [NativeTypeName("XEvent *")] XEvent* event_return);
 
-        [DllImport(libraryPath, EntryPoint = "XCirculateSubwindows", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XCirculateSubwindows", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XCirculateSubwindows([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Window")] UIntPtr w, int direction);
 
-        [DllImport(libraryPath, EntryPoint = "XCirculateSubwindowsDown", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XCirculateSubwindowsDown", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XCirculateSubwindowsDown([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Window")] UIntPtr w);
 
-        [DllImport(libraryPath, EntryPoint = "XCirculateSubwindowsUp", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XCirculateSubwindowsUp", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XCirculateSubwindowsUp([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Window")] UIntPtr w);
 
-        [DllImport(libraryPath, EntryPoint = "XClearArea", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XClearArea", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XClearArea([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Window")] UIntPtr w, int x, int y, [NativeTypeName("unsigned int")] uint width, [NativeTypeName("unsigned int")] uint height, int exposures);
 
-        [DllImport(libraryPath, EntryPoint = "XClearWindow", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XClearWindow", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XClearWindow([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Window")] UIntPtr w);
 
-        [DllImport(libraryPath, EntryPoint = "XCloseDisplay", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XCloseDisplay", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XCloseDisplay([NativeTypeName("Display *")] UIntPtr display);
 
-        [DllImport(libraryPath, EntryPoint = "XConfigureWindow", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XConfigureWindow", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XConfigureWindow([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Window")] UIntPtr w, [NativeTypeName("unsigned int")] uint value_mask, [NativeTypeName("XWindowChanges *")] XWindowChanges* values);
 
-        [DllImport(libraryPath, EntryPoint = "XConnectionNumber", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XConnectionNumber", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XConnectionNumber([NativeTypeName("Display *")] UIntPtr display);
 
-        [DllImport(libraryPath, EntryPoint = "XConvertSelection", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XConvertSelection", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XConvertSelection([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Atom")] UIntPtr selection, [NativeTypeName("Atom")] UIntPtr target, [NativeTypeName("Atom")] UIntPtr property, [NativeTypeName("Window")] UIntPtr requestor, [NativeTypeName("Time")] UIntPtr time);
 
-        [DllImport(libraryPath, EntryPoint = "XCopyArea", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XCopyArea", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XCopyArea([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Drawable")] UIntPtr src, [NativeTypeName("Drawable")] UIntPtr dest, [NativeTypeName("GC")] XGC* gc, int src_x, int src_y, [NativeTypeName("unsigned int")] uint width, [NativeTypeName("unsigned int")] uint height, int dest_x, int dest_y);
 
-        [DllImport(libraryPath, EntryPoint = "XCopyGC", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XCopyGC", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XCopyGC([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("GC")] XGC* src, [NativeTypeName("unsigned long")] UIntPtr valuemask, [NativeTypeName("GC")] XGC* dest);
 
-        [DllImport(libraryPath, EntryPoint = "XCopyPlane", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XCopyPlane", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XCopyPlane([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Drawable")] UIntPtr src, [NativeTypeName("Drawable")] UIntPtr dest, [NativeTypeName("GC")] XGC* gc, int src_x, int src_y, [NativeTypeName("unsigned int")] uint width, [NativeTypeName("unsigned int")] uint height, int dest_x, int dest_y, [NativeTypeName("unsigned long")] UIntPtr plane);
 
-        [DllImport(libraryPath, EntryPoint = "XDefaultDepth", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XDefaultDepth", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XDefaultDepth([NativeTypeName("Display *")] UIntPtr display, int screen_number);
 
-        [DllImport(libraryPath, EntryPoint = "XDefaultDepthOfScreen", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XDefaultDepthOfScreen", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XDefaultDepthOfScreen([NativeTypeName("Screen *")] Screen* screen);
 
-        [DllImport(libraryPath, EntryPoint = "XDefaultScreen", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XDefaultScreen", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XDefaultScreen([NativeTypeName("Display *")] UIntPtr display);
 
-        [DllImport(libraryPath, EntryPoint = "XDefineCursor", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XDefineCursor", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XDefineCursor([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Window")] UIntPtr w, [NativeTypeName("Cursor")] UIntPtr cursor);
 
-        [DllImport(libraryPath, EntryPoint = "XDeleteProperty", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XDeleteProperty", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XDeleteProperty([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Window")] UIntPtr w, [NativeTypeName("Atom")] UIntPtr property);
 
-        [DllImport(libraryPath, EntryPoint = "XDestroyWindow", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XDestroyWindow", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XDestroyWindow([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Window")] UIntPtr w);
 
-        [DllImport(libraryPath, EntryPoint = "XDestroySubwindows", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XDestroySubwindows", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XDestroySubwindows([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Window")] UIntPtr w);
 
-        [DllImport(libraryPath, EntryPoint = "XDoesBackingStore", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XDoesBackingStore", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XDoesBackingStore([NativeTypeName("Screen *")] Screen* screen);
 
-        [DllImport(libraryPath, EntryPoint = "XDoesSaveUnders", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XDoesSaveUnders", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XDoesSaveUnders([NativeTypeName("Screen *")] Screen* screen);
 
-        [DllImport(libraryPath, EntryPoint = "XDisableAccessControl", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XDisableAccessControl", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XDisableAccessControl([NativeTypeName("Display *")] UIntPtr display);
 
-        [DllImport(libraryPath, EntryPoint = "XDisplayCells", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XDisplayCells", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XDisplayCells([NativeTypeName("Display *")] UIntPtr display, int screen_number);
 
-        [DllImport(libraryPath, EntryPoint = "XDisplayHeight", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XDisplayHeight", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XDisplayHeight([NativeTypeName("Display *")] UIntPtr display, int screen_number);
 
-        [DllImport(libraryPath, EntryPoint = "XDisplayHeightMM", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XDisplayHeightMM", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XDisplayHeightMM([NativeTypeName("Display *")] UIntPtr display, int screen_number);
 
-        [DllImport(libraryPath, EntryPoint = "XDisplayKeycodes", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XDisplayKeycodes", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XDisplayKeycodes([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("int *")] int* min_keycodes_return, [NativeTypeName("int *")] int* max_keycodes_return);
 
-        [DllImport(libraryPath, EntryPoint = "XDisplayPlanes", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XDisplayPlanes", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XDisplayPlanes([NativeTypeName("Display *")] UIntPtr display, int screen_numberm1);
 
-        [DllImport(libraryPath, EntryPoint = "XDisplayWidth", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XDisplayWidth", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XDisplayWidth([NativeTypeName("Display *")] UIntPtr display, int screen_number);
 
-        [DllImport(libraryPath, EntryPoint = "XDisplayWidthMM", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XDisplayWidthMM", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XDisplayWidthMM([NativeTypeName("Display *")] UIntPtr display, int screen_number);
 
-        [DllImport(libraryPath, EntryPoint = "XDrawArc", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XDrawArc", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XDrawArc([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Drawable")] UIntPtr d, [NativeTypeName("GC")] XGC* gc, int x, int y, [NativeTypeName("unsigned int")] uint width, [NativeTypeName("unsigned int")] uint height, int angle1, int angle2);
 
-        [DllImport(libraryPath, EntryPoint = "XDrawArcs", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XDrawArcs", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XDrawArcs([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Drawable")] UIntPtr d, [NativeTypeName("GC")] XGC* gc, [NativeTypeName("XArc *")] XArc* arcs, int narcs);
 
-        [DllImport(libraryPath, EntryPoint = "XDrawImageString", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XDrawImageString", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XDrawImageString([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Drawable")] UIntPtr d, [NativeTypeName("GC")] XGC* gc, int x, int y, [NativeTypeName("const char *")] sbyte* c_string, int length);
 
-        [DllImport(libraryPath, EntryPoint = "XDrawImageString16", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XDrawImageString16", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XDrawImageString16([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Drawable")] UIntPtr d, [NativeTypeName("GC")] XGC* gc, int x, int y, [NativeTypeName("const XChar2b *")] XChar2b* c_string, int length);
 
-        [DllImport(libraryPath, EntryPoint = "XDrawLine", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XDrawLine", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XDrawLine([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Drawable")] UIntPtr d, [NativeTypeName("GC")] XGC* gc, int x1, int y1, int x2, int y2);
 
-        [DllImport(libraryPath, EntryPoint = "XDrawLines", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XDrawLines", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XDrawLines([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Drawable")] UIntPtr d, [NativeTypeName("GC")] XGC* gc, [NativeTypeName("XPoint *")] XPoint* points, int npoints, int mode);
 
-        [DllImport(libraryPath, EntryPoint = "XDrawPoint", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XDrawPoint", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XDrawPoint([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Drawable")] UIntPtr d, [NativeTypeName("GC")] XGC* gc, int x, int y);
 
-        [DllImport(libraryPath, EntryPoint = "XDrawPoints", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XDrawPoints", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XDrawPoints([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Drawable")] UIntPtr d, [NativeTypeName("GC")] XGC* gc, [NativeTypeName("XPoint *")] XPoint* points, int npoints, int mode);
 
-        [DllImport(libraryPath, EntryPoint = "XDrawRectangle", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XDrawRectangle", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XDrawRectangle([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Drawable")] UIntPtr d, [NativeTypeName("GC")] XGC* gc, int x, int y, [NativeTypeName("unsigned int")] uint width, [NativeTypeName("unsigned int")] uint height);
 
-        [DllImport(libraryPath, EntryPoint = "XDrawRectangles", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XDrawRectangles", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XDrawRectangles([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Drawable")] UIntPtr d, [NativeTypeName("GC")] XGC* gc, [NativeTypeName("XRectangle *")] XRectangle* rectangles, int nrectangles);
 
-        [DllImport(libraryPath, EntryPoint = "XDrawSegments", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XDrawSegments", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XDrawSegments([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Drawable")] UIntPtr d, [NativeTypeName("GC")] XGC* gc, [NativeTypeName("XSegment *")] XSegment* segments, int nsegments);
 
-        [DllImport(libraryPath, EntryPoint = "XDrawString", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XDrawString", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XDrawString([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Drawable")] UIntPtr d, [NativeTypeName("GC")] XGC* gc, int x, int y, [NativeTypeName("const char *")] sbyte* c_string, int length);
 
-        [DllImport(libraryPath, EntryPoint = "XDrawString16", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XDrawString16", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XDrawString16([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Drawable")] UIntPtr d, [NativeTypeName("GC")] XGC* gc, int x, int y, [NativeTypeName("const XChar2b *")] XChar2b* c_string, int length);
 
-        [DllImport(libraryPath, EntryPoint = "XDrawText", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XDrawText", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XDrawText([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Drawable")] UIntPtr d, [NativeTypeName("GC")] XGC* gc, int x, int y, [NativeTypeName("XTextItem *")] XTextItem* items, int nitems);
 
-        [DllImport(libraryPath, EntryPoint = "XDrawText16", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XDrawText16", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XDrawText16([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Drawable")] UIntPtr d, [NativeTypeName("GC")] XGC* gc, int x, int y, [NativeTypeName("XTextItem16 *")] XTextItem16* items, int nitems);
 
-        [DllImport(libraryPath, EntryPoint = "XEnableAccessControl", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XEnableAccessControl", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XEnableAccessControl([NativeTypeName("Display *")] UIntPtr display);
 
-        [DllImport(libraryPath, EntryPoint = "XEventsQueued", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XEventsQueued", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XEventsQueued([NativeTypeName("Display *")] UIntPtr display, int mode);
 
-        [DllImport(libraryPath, EntryPoint = "XFetchName", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XFetchName", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XFetchName([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Window")] UIntPtr w, [NativeTypeName("char **")] sbyte** window_name_return);
 
-        [DllImport(libraryPath, EntryPoint = "XFillArc", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XFillArc", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XFillArc([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Drawable")] UIntPtr d, [NativeTypeName("GC")] XGC* gc, int x, int y, [NativeTypeName("unsigned int")] uint width, [NativeTypeName("unsigned int")] uint height, int angle1, int angle2);
 
-        [DllImport(libraryPath, EntryPoint = "XFillArcs", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XFillArcs", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XFillArcs([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Drawable")] UIntPtr d, [NativeTypeName("GC")] XGC* gc, [NativeTypeName("XArc *")] XArc* arcs, int narcs);
 
-        [DllImport(libraryPath, EntryPoint = "XFillPolygon", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XFillPolygon", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XFillPolygon([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Drawable")] UIntPtr d, [NativeTypeName("GC")] XGC* gc, [NativeTypeName("XPoint *")] XPoint* points, int npoints, int shape, int mode);
 
-        [DllImport(libraryPath, EntryPoint = "XFillRectangle", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XFillRectangle", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XFillRectangle([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Drawable")] UIntPtr d, [NativeTypeName("GC")] XGC* gc, int x, int y, [NativeTypeName("unsigned int")] uint width, [NativeTypeName("unsigned int")] uint height);
 
-        [DllImport(libraryPath, EntryPoint = "XFillRectangles", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XFillRectangles", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XFillRectangles([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Drawable")] UIntPtr d, [NativeTypeName("GC")] XGC* gc, [NativeTypeName("XRectangle *")] XRectangle* rectangles, int nrectangles);
 
-        [DllImport(libraryPath, EntryPoint = "XFlush", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XFlush", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XFlush([NativeTypeName("Display *")] UIntPtr display);
 
-        [DllImport(libraryPath, EntryPoint = "XForceScreenSaver", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XForceScreenSaver", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XForceScreenSaver([NativeTypeName("Display *")] UIntPtr display, int mode);
 
-        [DllImport(libraryPath, EntryPoint = "XFree", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XFree", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XFree([NativeTypeName("void *")] void* data);
 
-        [DllImport(libraryPath, EntryPoint = "XFreeColormap", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XFreeColormap", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XFreeColormap([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Colormap")] UIntPtr colormap);
 
-        [DllImport(libraryPath, EntryPoint = "XFreeColors", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XFreeColors", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XFreeColors([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Colormap")] UIntPtr colormap, [NativeTypeName("unsigned long *")] UIntPtr* pixels, int npixels, [NativeTypeName("unsigned long")] UIntPtr planes);
 
-        [DllImport(libraryPath, EntryPoint = "XFreeCursor", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XFreeCursor", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XFreeCursor([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Cursor")] UIntPtr cursor);
 
-        [DllImport(libraryPath, EntryPoint = "XFreeExtensionList", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XFreeExtensionList", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XFreeExtensionList([NativeTypeName("char **")] sbyte** list);
 
-        [DllImport(libraryPath, EntryPoint = "XFreeFont", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XFreeFont", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XFreeFont([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("XFontStruct *")] XFontStruct* font_struct);
 
-        [DllImport(libraryPath, EntryPoint = "XFreeFontInfo", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XFreeFontInfo", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XFreeFontInfo([NativeTypeName("char **")] sbyte** names, [NativeTypeName("XFontStruct *")] XFontStruct* free_info, int actual_count);
 
-        [DllImport(libraryPath, EntryPoint = "XFreeFontNames", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XFreeFontNames", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XFreeFontNames([NativeTypeName("char **")] sbyte** list);
 
-        [DllImport(libraryPath, EntryPoint = "XFreeFontPath", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XFreeFontPath", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XFreeFontPath([NativeTypeName("char **")] sbyte** list);
 
-        [DllImport(libraryPath, EntryPoint = "XFreeGC", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XFreeGC", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XFreeGC([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("GC")] XGC* gc);
 
-        [DllImport(libraryPath, EntryPoint = "XFreeModifiermap", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XFreeModifiermap", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XFreeModifiermap([NativeTypeName("XModifierKeymap *")] XModifierKeymap* modmap);
 
-        [DllImport(libraryPath, EntryPoint = "XFreePixmap", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XFreePixmap", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XFreePixmap([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Pixmap")] UIntPtr pixmap);
 
-        [DllImport(libraryPath, EntryPoint = "XGeometry", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XGeometry", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XGeometry([NativeTypeName("Display *")] UIntPtr display, int screen, [NativeTypeName("const char *")] sbyte* position, [NativeTypeName("const char *")] sbyte* default_position, [NativeTypeName("unsigned int")] uint bwidth, [NativeTypeName("unsigned int")] uint fwidth, [NativeTypeName("unsigned int")] uint fheight, int xadder, int yadder, [NativeTypeName("int *")] int* x_return, [NativeTypeName("int *")] int* y_return, [NativeTypeName("int *")] int* width_return, [NativeTypeName("int *")] int* height_return);
 
-        [DllImport(libraryPath, EntryPoint = "XGetErrorDatabaseText", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XGetErrorDatabaseText", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XGetErrorDatabaseText([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("const char *")] sbyte* name, [NativeTypeName("const char *")] sbyte* message, [NativeTypeName("const char *")] sbyte* default_string, [NativeTypeName("char *")] sbyte* buffer_return, int length);
 
-        [DllImport(libraryPath, EntryPoint = "XGetErrorText", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XGetErrorText", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XGetErrorText([NativeTypeName("Display *")] UIntPtr display, int code, [NativeTypeName("char *")] sbyte* buffer_return, int length);
 
-        [DllImport(libraryPath, EntryPoint = "XGetFontProperty", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XGetFontProperty", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XGetFontProperty([NativeTypeName("XFontStruct *")] XFontStruct* font_struct, [NativeTypeName("Atom")] UIntPtr atom, [NativeTypeName("unsigned long *")] UIntPtr* value_return);
 
-        [DllImport(libraryPath, EntryPoint = "XGetGCValues", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XGetGCValues", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XGetGCValues([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("GC")] XGC* gc, [NativeTypeName("unsigned long")] UIntPtr valuemask, [NativeTypeName("XGCValues *")] XGCValues* values_return);
 
-        [DllImport(libraryPath, EntryPoint = "XGetGeometry", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XGetGeometry", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XGetGeometry([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Drawable")] UIntPtr d, [NativeTypeName("Window *")] UIntPtr* root_return, [NativeTypeName("int *")] int* x_return, [NativeTypeName("int *")] int* y_return, [NativeTypeName("unsigned int *")] uint* width_return, [NativeTypeName("unsigned int *")] uint* height_return, [NativeTypeName("unsigned int *")] uint* border_width_return, [NativeTypeName("unsigned int *")] uint* depth_return);
 
-        [DllImport(libraryPath, EntryPoint = "XGetIconName", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XGetIconName", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XGetIconName([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Window")] UIntPtr w, [NativeTypeName("char **")] sbyte** icon_name_return);
 
-        [DllImport(libraryPath, EntryPoint = "XGetInputFocus", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XGetInputFocus", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XGetInputFocus([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Window *")] UIntPtr* focus_return, [NativeTypeName("int *")] int* revert_to_return);
 
-        [DllImport(libraryPath, EntryPoint = "XGetKeyboardControl", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XGetKeyboardControl", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XGetKeyboardControl([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("XKeyboardState *")] XKeyboardState* values_return);
 
-        [DllImport(libraryPath, EntryPoint = "XGetPointerControl", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XGetPointerControl", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XGetPointerControl([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("int *")] int* accel_numerator_return, [NativeTypeName("int *")] int* accel_denominator_return, [NativeTypeName("int *")] int* threshold_return);
 
-        [DllImport(libraryPath, EntryPoint = "XGetPointerMapping", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XGetPointerMapping", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XGetPointerMapping([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("unsigned char *")] byte* map_return, int map);
 
-        [DllImport(libraryPath, EntryPoint = "XGetScreenSaver", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XGetScreenSaver", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XGetScreenSaver([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("int *")] int* timeout_return, [NativeTypeName("int *")] int* interval_return, [NativeTypeName("int *")] int* prefer_blanking_return, [NativeTypeName("int *")] int* allow_exposures_return);
 
-        [DllImport(libraryPath, EntryPoint = "XGetTransientForHint", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XGetTransientForHint", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XGetTransientForHint([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Window")] UIntPtr w, [NativeTypeName("Window *")] UIntPtr* prop_window_return);
 
-        [DllImport(libraryPath, EntryPoint = "XGetWindowProperty", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XGetWindowProperty", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XGetWindowProperty([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Window")] UIntPtr w, [NativeTypeName("Atom")] UIntPtr property, [NativeTypeName("long")] IntPtr long_offset, [NativeTypeName("long")] IntPtr long_length, int delete, [NativeTypeName("Atom")] UIntPtr req_type, [NativeTypeName("Atom *")] UIntPtr* actual_type_return, [NativeTypeName("int *")] int* actual_format_return, [NativeTypeName("unsigned long *")] UIntPtr* nitems_return, [NativeTypeName("unsigned long *")] UIntPtr* bytes_after_return, [NativeTypeName("unsigned char **")] byte** prop_return);
 
-        [DllImport(libraryPath, EntryPoint = "XGetWindowAttributes", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XGetWindowAttributes", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XGetWindowAttributes([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Window")] UIntPtr w, [NativeTypeName("XWindowAttributes *")] XWindowAttributes* window_attributes_return);
 
-        [DllImport(libraryPath, EntryPoint = "XGrabButton", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XGrabButton", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XGrabButton([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("unsigned int")] uint button, [NativeTypeName("unsigned int")] uint modifiers, [NativeTypeName("Window")] UIntPtr grab_window, int owner_events, [NativeTypeName("unsigned int")] uint event_mask, int pointer_mode, int keyboard_mode, [NativeTypeName("Window")] UIntPtr confine_to, [NativeTypeName("Cursor")] UIntPtr cursor);
 
-        [DllImport(libraryPath, EntryPoint = "XGrabKey", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XGrabKey", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XGrabKey([NativeTypeName("Display *")] UIntPtr display, int keycode, [NativeTypeName("unsigned int")] uint modifiers, [NativeTypeName("Window")] UIntPtr grab_window, int owner_events, int pointer_mode, int keyboard_mode);
 
-        [DllImport(libraryPath, EntryPoint = "XGrabKeyboard", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XGrabKeyboard", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XGrabKeyboard([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Window")] UIntPtr grab_window, int owner_events, int pointer_mode, int keyboard_mode, [NativeTypeName("Time")] UIntPtr time);
 
-        [DllImport(libraryPath, EntryPoint = "XGrabPointer", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XGrabPointer", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XGrabPointer([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Window")] UIntPtr grab_window, int owner_events, [NativeTypeName("unsigned int")] uint event_mask, int pointer_mode, int keyboard_mode, [NativeTypeName("Window")] UIntPtr confine_to, [NativeTypeName("Cursor")] UIntPtr cursor, [NativeTypeName("Time")] UIntPtr time);
 
-        [DllImport(libraryPath, EntryPoint = "XGrabServer", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XGrabServer", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XGrabServer([NativeTypeName("Display *")] UIntPtr display);
 
-        [DllImport(libraryPath, EntryPoint = "XHeightMMOfScreen", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XHeightMMOfScreen", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XHeightMMOfScreen([NativeTypeName("Screen *")] Screen* screen);
 
-        [DllImport(libraryPath, EntryPoint = "XHeightOfScreen", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XHeightOfScreen", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XHeightOfScreen([NativeTypeName("Screen *")] Screen* screen);
 
-        [DllImport(libraryPath, EntryPoint = "XIfEvent", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XIfEvent", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XIfEvent([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("XEvent *")] XEvent* event_return, [NativeTypeName("int (*)(Display *, XEvent *, XPointer)")] IntPtr predicate, [NativeTypeName("XPointer")] sbyte* arg);
 
-        [DllImport(libraryPath, EntryPoint = "XImageByteOrder", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XImageByteOrder", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XImageByteOrder([NativeTypeName("Display *")] UIntPtr display);
 
-        [DllImport(libraryPath, EntryPoint = "XInstallColormap", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XInstallColormap", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XInstallColormap([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Colormap")] UIntPtr colormap);
 
-        [DllImport(libraryPath, EntryPoint = "XKeysymToKeycode", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XKeysymToKeycode", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("KeyCode")]
         public static extern byte XKeysymToKeycode([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("KeySym")] UIntPtr keysym);
 
-        [DllImport(libraryPath, EntryPoint = "XKillClient", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XKillClient", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XKillClient([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("XID")] UIntPtr resource);
 
-        [DllImport(libraryPath, EntryPoint = "XLookupColor", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XLookupColor", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XLookupColor([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Colormap")] UIntPtr colormap, [NativeTypeName("const char *")] sbyte* color_name, [NativeTypeName("XColor *")] XColor* exact_def_return, [NativeTypeName("XColor *")] XColor* screen_def_return);
 
-        [DllImport(libraryPath, EntryPoint = "XLowerWindow", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XLowerWindow", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XLowerWindow([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Window")] UIntPtr w);
 
-        [DllImport(libraryPath, EntryPoint = "XMapRaised", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XMapRaised", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XMapRaised([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Window")] UIntPtr w);
 
-        [DllImport(libraryPath, EntryPoint = "XMapSubwindows", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XMapSubwindows", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XMapSubwindows([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Window")] UIntPtr w);
 
-        [DllImport(libraryPath, EntryPoint = "XMapWindow", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XMapWindow", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XMapWindow([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Window")] UIntPtr w);
 
-        [DllImport(libraryPath, EntryPoint = "XMaskEvent", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XMaskEvent", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XMaskEvent([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("long")] IntPtr event_mask, [NativeTypeName("XEvent *")] XEvent* event_return);
 
-        [DllImport(libraryPath, EntryPoint = "XMaxCmapsOfScreen", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XMaxCmapsOfScreen", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XMaxCmapsOfScreen([NativeTypeName("Screen *")] Screen* screen);
 
-        [DllImport(libraryPath, EntryPoint = "XMinCmapsOfScreen", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XMinCmapsOfScreen", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XMinCmapsOfScreen([NativeTypeName("Screen *")] Screen* screen);
 
-        [DllImport(libraryPath, EntryPoint = "XMoveResizeWindow", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XMoveResizeWindow", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XMoveResizeWindow([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Window")] UIntPtr w, int x, int y, [NativeTypeName("unsigned int")] uint width, [NativeTypeName("unsigned int")] uint height);
 
-        [DllImport(libraryPath, EntryPoint = "XMoveWindow", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XMoveWindow", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XMoveWindow([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Window")] UIntPtr w, int x, int y);
 
-        [DllImport(libraryPath, EntryPoint = "XNextEvent", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XNextEvent", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XNextEvent([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("XEvent *")] XEvent* event_return);
 
-        [DllImport(libraryPath, EntryPoint = "XNoOp", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XNoOp", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XNoOp([NativeTypeName("Display *")] UIntPtr display);
 
-        [DllImport(libraryPath, EntryPoint = "XParseColor", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XParseColor", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XParseColor([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Colormap")] UIntPtr colormap, [NativeTypeName("const char *")] sbyte* spec, [NativeTypeName("XColor *")] XColor* exact_def_return);
 
-        [DllImport(libraryPath, EntryPoint = "XParseGeometry", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XParseGeometry", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XParseGeometry([NativeTypeName("const char *")] sbyte* parsestring, [NativeTypeName("int *")] int* x_return, [NativeTypeName("int *")] int* y_return, [NativeTypeName("unsigned int *")] uint* width_return, [NativeTypeName("unsigned int *")] uint* height_return);
 
-        [DllImport(libraryPath, EntryPoint = "XPeekEvent", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XPeekEvent", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XPeekEvent([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("XEvent *")] XEvent* event_return);
 
-        [DllImport(libraryPath, EntryPoint = "XPeekIfEvent", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XPeekIfEvent", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XPeekIfEvent([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("XEvent *")] XEvent* event_return, [NativeTypeName("int (*)(Display *, XEvent *, XPointer)")] IntPtr predicate, [NativeTypeName("XPointer")] sbyte* arg);
 
-        [DllImport(libraryPath, EntryPoint = "XPending", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XPending", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XPending([NativeTypeName("Display *")] UIntPtr display);
 
-        [DllImport(libraryPath, EntryPoint = "XPlanesOfScreen", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XPlanesOfScreen", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XPlanesOfScreen([NativeTypeName("Screen *")] Screen* screen);
 
-        [DllImport(libraryPath, EntryPoint = "XProtocolRevision", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XProtocolRevision", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XProtocolRevision([NativeTypeName("Display *")] UIntPtr display);
 
-        [DllImport(libraryPath, EntryPoint = "XProtocolVersion", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XProtocolVersion", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XProtocolVersion([NativeTypeName("Display *")] UIntPtr display);
 
-        [DllImport(libraryPath, EntryPoint = "XPutBackEvent", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XPutBackEvent", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XPutBackEvent([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("XEvent *")] XEvent* c_event);
 
-        [DllImport(libraryPath, EntryPoint = "XPutImage", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XPutImage", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XPutImage([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Drawable")] UIntPtr d, [NativeTypeName("GC")] XGC* gc, [NativeTypeName("XImage *")] XImage* image, int src_x, int src_y, int dest_x, int dest_y, [NativeTypeName("unsigned int")] uint width, [NativeTypeName("unsigned int")] uint height);
 
-        [DllImport(libraryPath, EntryPoint = "XQLength", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XQLength", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XQLength([NativeTypeName("Display *")] UIntPtr display);
 
-        [DllImport(libraryPath, EntryPoint = "XQueryBestCursor", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XQueryBestCursor", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XQueryBestCursor([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Drawable")] UIntPtr d, [NativeTypeName("unsigned int")] uint width, [NativeTypeName("unsigned int")] uint height, [NativeTypeName("unsigned int *")] uint* width_return, [NativeTypeName("unsigned int *")] uint* height_return);
 
-        [DllImport(libraryPath, EntryPoint = "XQueryBestSize", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XQueryBestSize", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XQueryBestSize([NativeTypeName("Display *")] UIntPtr display, int c_class, [NativeTypeName("Drawable")] UIntPtr which_screen, [NativeTypeName("unsigned int")] uint width, [NativeTypeName("unsigned int")] uint height, [NativeTypeName("unsigned int *")] uint* width_return, [NativeTypeName("unsigned int *")] uint* height_return);
 
-        [DllImport(libraryPath, EntryPoint = "XQueryBestStipple", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XQueryBestStipple", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XQueryBestStipple([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Drawable")] UIntPtr which_screen, [NativeTypeName("unsigned int")] uint width, [NativeTypeName("unsigned int")] uint height, [NativeTypeName("unsigned int *")] uint* width_return, [NativeTypeName("unsigned int *")] uint* height_return);
 
-        [DllImport(libraryPath, EntryPoint = "XQueryBestTile", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XQueryBestTile", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XQueryBestTile([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Drawable")] UIntPtr which_screen, [NativeTypeName("unsigned int")] uint width, [NativeTypeName("unsigned int")] uint height, [NativeTypeName("unsigned int *")] uint* width_return, [NativeTypeName("unsigned int *")] uint* height_return);
 
-        [DllImport(libraryPath, EntryPoint = "XQueryColor", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XQueryColor", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XQueryColor([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Colormap")] UIntPtr colormap, [NativeTypeName("XColor *")] XColor* def_in_out);
 
-        [DllImport(libraryPath, EntryPoint = "XQueryColors", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XQueryColors", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XQueryColors([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Colormap")] UIntPtr colormap, [NativeTypeName("XColor *")] XColor* defs_in_out, int ncolors);
 
-        [DllImport(libraryPath, EntryPoint = "XQueryExtension", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XQueryExtension", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XQueryExtension([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("const char *")] sbyte* name, [NativeTypeName("int *")] int* major_opcode_return, [NativeTypeName("int *")] int* first_event_return, [NativeTypeName("int *")] int* first_error_return);
 
-        [DllImport(libraryPath, EntryPoint = "XQueryKeymap", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XQueryKeymap", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XQueryKeymap([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("char [32]")] sbyte keys_return);
 
-        [DllImport(libraryPath, EntryPoint = "XQueryPointer", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XQueryPointer", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XQueryPointer([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Window")] UIntPtr w, [NativeTypeName("Window *")] UIntPtr* root_return, [NativeTypeName("Window *")] UIntPtr* child_return, [NativeTypeName("int *")] int* root_x_return, [NativeTypeName("int *")] int* root_y_return, [NativeTypeName("int *")] int* win_x_return, [NativeTypeName("int *")] int* win_y_return, [NativeTypeName("unsigned int *")] uint* mask_return);
 
-        [DllImport(libraryPath, EntryPoint = "XQueryTextExtents", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XQueryTextExtents", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XQueryTextExtents([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("XID")] UIntPtr font_ID, [NativeTypeName("const char *")] sbyte* c_string, int nchars, [NativeTypeName("int *")] int* direction_return, [NativeTypeName("int *")] int* font_ascent_return, [NativeTypeName("int *")] int* font_descent_return, [NativeTypeName("XCharStruct *")] XCharStruct* overall_return);
 
-        [DllImport(libraryPath, EntryPoint = "XQueryTextExtents16", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XQueryTextExtents16", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XQueryTextExtents16([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("XID")] UIntPtr font_ID, [NativeTypeName("const XChar2b *")] XChar2b* c_string, int nchars, [NativeTypeName("int *")] int* direction_return, [NativeTypeName("int *")] int* font_ascent_return, [NativeTypeName("int *")] int* font_descent_return, [NativeTypeName("XCharStruct *")] XCharStruct* overall_return);
 
-        [DllImport(libraryPath, EntryPoint = "XQueryTree", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XQueryTree", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XQueryTree([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Window")] UIntPtr w, [NativeTypeName("Window *")] UIntPtr* root_return, [NativeTypeName("Window *")] UIntPtr* parent_return, [NativeTypeName("Window **")] UIntPtr** children_return, [NativeTypeName("unsigned int *")] uint* nchildren_return);
 
-        [DllImport(libraryPath, EntryPoint = "XRaiseWindow", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XRaiseWindow", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XRaiseWindow([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Window")] UIntPtr w);
 
-        [DllImport(libraryPath, EntryPoint = "XReadBitmapFile", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XReadBitmapFile", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XReadBitmapFile([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Drawable")] UIntPtr d, [NativeTypeName("const char *")] sbyte* filename, [NativeTypeName("unsigned int *")] uint* width_return, [NativeTypeName("unsigned int *")] uint* height_return, [NativeTypeName("Pixmap *")] UIntPtr* bitmap_return, [NativeTypeName("int *")] int* x_hot_return, [NativeTypeName("int *")] int* y_hot_return);
 
-        [DllImport(libraryPath, EntryPoint = "XReadBitmapFileData", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XReadBitmapFileData", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XReadBitmapFileData([NativeTypeName("const char *")] sbyte* filename, [NativeTypeName("unsigned int *")] uint* width_return, [NativeTypeName("unsigned int *")] uint* height_return, [NativeTypeName("unsigned char **")] byte** data_return, [NativeTypeName("int *")] int* x_hot_return, [NativeTypeName("int *")] int* y_hot_return);
 
-        [DllImport(libraryPath, EntryPoint = "XRebindKeysym", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XRebindKeysym", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XRebindKeysym([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("KeySym")] UIntPtr keysym, [NativeTypeName("KeySym *")] UIntPtr* list, int mod_count, [NativeTypeName("const unsigned char *")] byte* c_string, int bytes_string);
 
-        [DllImport(libraryPath, EntryPoint = "XRecolorCursor", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XRecolorCursor", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XRecolorCursor([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Cursor")] UIntPtr cursor, [NativeTypeName("XColor *")] XColor* foreground_color, [NativeTypeName("XColor *")] XColor* background_color);
 
-        [DllImport(libraryPath, EntryPoint = "XRefreshKeyboardMapping", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XRefreshKeyboardMapping", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XRefreshKeyboardMapping([NativeTypeName("XMappingEvent *")] XMappingEvent* event_map);
 
-        [DllImport(libraryPath, EntryPoint = "XRemoveFromSaveSet", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XRemoveFromSaveSet", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XRemoveFromSaveSet([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Window")] UIntPtr w);
 
-        [DllImport(libraryPath, EntryPoint = "XRemoveHost", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XRemoveHost", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XRemoveHost([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("XHostAddress *")] XHostAddress* host);
 
-        [DllImport(libraryPath, EntryPoint = "XRemoveHosts", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XRemoveHosts", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XRemoveHosts([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("XHostAddress *")] XHostAddress* hosts, int num_hosts);
 
-        [DllImport(libraryPath, EntryPoint = "XReparentWindow", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XReparentWindow", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XReparentWindow([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Window")] UIntPtr w, [NativeTypeName("Window")] UIntPtr parent, int x, int y);
 
-        [DllImport(libraryPath, EntryPoint = "XResetScreenSaver", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XResetScreenSaver", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XResetScreenSaver([NativeTypeName("Display *")] UIntPtr display);
 
-        [DllImport(libraryPath, EntryPoint = "XResizeWindow", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XResizeWindow", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XResizeWindow([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Window")] UIntPtr w, [NativeTypeName("unsigned int")] uint width, [NativeTypeName("unsigned int")] uint height);
 
-        [DllImport(libraryPath, EntryPoint = "XRestackWindows", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XRestackWindows", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XRestackWindows([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Window *")] UIntPtr* windows, int nwindows);
 
-        [DllImport(libraryPath, EntryPoint = "XRotateBuffers", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XRotateBuffers", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XRotateBuffers([NativeTypeName("Display *")] UIntPtr display, int rotate);
 
-        [DllImport(libraryPath, EntryPoint = "XRotateWindowProperties", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XRotateWindowProperties", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XRotateWindowProperties([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Window")] UIntPtr w, [NativeTypeName("Atom *")] UIntPtr* properties, int num_prop, int npositions);
 
-        [DllImport(libraryPath, EntryPoint = "XScreenCount", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XScreenCount", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XScreenCount([NativeTypeName("Display *")] UIntPtr display);
 
-        [DllImport(libraryPath, EntryPoint = "XSelectInput", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XSelectInput", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XSelectInput([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Window")] UIntPtr w, [NativeTypeName("long")] IntPtr event_mask);
 
-        [DllImport(libraryPath, EntryPoint = "XSendEvent", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XSendEvent", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XSendEvent([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Window")] UIntPtr w, int propagate, [NativeTypeName("long")] IntPtr event_mask, [NativeTypeName("XEvent *")] XEvent* event_send);
 
-        [DllImport(libraryPath, EntryPoint = "XSetAccessControl", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XSetAccessControl", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XSetAccessControl([NativeTypeName("Display *")] UIntPtr display, int mode);
 
-        [DllImport(libraryPath, EntryPoint = "XSetArcMode", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XSetArcMode", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XSetArcMode([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("GC")] XGC* gc, int arc_mode);
 
-        [DllImport(libraryPath, EntryPoint = "XSetBackground", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XSetBackground", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XSetBackground([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("GC")] XGC* gc, [NativeTypeName("unsigned long")] UIntPtr background);
 
-        [DllImport(libraryPath, EntryPoint = "XSetClipMask", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XSetClipMask", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XSetClipMask([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("GC")] XGC* gc, [NativeTypeName("Pixmap")] UIntPtr pixmap);
 
-        [DllImport(libraryPath, EntryPoint = "XSetClipOrigin", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XSetClipOrigin", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XSetClipOrigin([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("GC")] XGC* gc, int clip_x_origin, int clip_y_origin);
 
-        [DllImport(libraryPath, EntryPoint = "XSetClipRectangles", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XSetClipRectangles", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XSetClipRectangles([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("GC")] XGC* gc, int clip_x_origin, int clip_y_origin, [NativeTypeName("XRectangle *")] XRectangle* rectangles, int n, int ordering);
 
-        [DllImport(libraryPath, EntryPoint = "XSetCloseDownMode", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XSetCloseDownMode", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XSetCloseDownMode([NativeTypeName("Display *")] UIntPtr display, int close_mode);
 
-        [DllImport(libraryPath, EntryPoint = "XSetCommand", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XSetCommand", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XSetCommand([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Window")] UIntPtr w, [NativeTypeName("char **")] sbyte** argv, int argc);
 
-        [DllImport(libraryPath, EntryPoint = "XSetDashes", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XSetDashes", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XSetDashes([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("GC")] XGC* gc, int dash_offset, [NativeTypeName("const char *")] sbyte* dash_list, int n);
 
-        [DllImport(libraryPath, EntryPoint = "XSetFillRule", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XSetFillRule", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XSetFillRule([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("GC")] XGC* gc, int fill_rule);
 
-        [DllImport(libraryPath, EntryPoint = "XSetFillStyle", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XSetFillStyle", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XSetFillStyle([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("GC")] XGC* gc, int fill_style);
 
-        [DllImport(libraryPath, EntryPoint = "XSetFont", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XSetFont", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XSetFont([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("GC")] XGC* gc, [NativeTypeName("Font")] UIntPtr font);
 
-        [DllImport(libraryPath, EntryPoint = "XSetFontPath", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XSetFontPath", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XSetFontPath([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("char **")] sbyte** directories, int ndirs);
 
-        [DllImport(libraryPath, EntryPoint = "XSetForeground", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XSetForeground", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XSetForeground([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("GC")] XGC* gc, [NativeTypeName("unsigned long")] UIntPtr foreground);
 
-        [DllImport(libraryPath, EntryPoint = "XSetFunction", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XSetFunction", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XSetFunction([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("GC")] XGC* gc, int function);
 
-        [DllImport(libraryPath, EntryPoint = "XSetGraphicsExposures", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XSetGraphicsExposures", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XSetGraphicsExposures([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("GC")] XGC* gc, int graphics_exposures);
 
-        [DllImport(libraryPath, EntryPoint = "XSetIconName", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XSetIconName", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XSetIconName([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Window")] UIntPtr w, [NativeTypeName("const char *")] sbyte* icon_name);
 
-        [DllImport(libraryPath, EntryPoint = "XSetInputFocus", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XSetInputFocus", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XSetInputFocus([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Window")] UIntPtr focus, int revert_to, [NativeTypeName("Time")] UIntPtr time);
 
-        [DllImport(libraryPath, EntryPoint = "XSetLineAttributes", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XSetLineAttributes", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XSetLineAttributes([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("GC")] XGC* gc, [NativeTypeName("unsigned int")] uint line_width, int line_style, int cap_style, int join_style);
 
-        [DllImport(libraryPath, EntryPoint = "XSetModifierMapping", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XSetModifierMapping", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XSetModifierMapping([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("XModifierKeymap *")] XModifierKeymap* modmap);
 
-        [DllImport(libraryPath, EntryPoint = "XSetPlaneMask", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XSetPlaneMask", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XSetPlaneMask([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("GC")] XGC* gc, [NativeTypeName("unsigned long")] UIntPtr plane_mask);
 
-        [DllImport(libraryPath, EntryPoint = "XSetPointerMapping", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XSetPointerMapping", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XSetPointerMapping([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("const unsigned char *")] byte* map, int nmap);
 
-        [DllImport(libraryPath, EntryPoint = "XSetScreenSaver", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XSetScreenSaver", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XSetScreenSaver([NativeTypeName("Display *")] UIntPtr display, int timeout, int interval, int prefer_blanking, int allow_exposures);
 
-        [DllImport(libraryPath, EntryPoint = "XSetSelectionOwner", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XSetSelectionOwner", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XSetSelectionOwner([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Atom")] UIntPtr selection, [NativeTypeName("Window")] UIntPtr owner, [NativeTypeName("Time")] UIntPtr time);
 
-        [DllImport(libraryPath, EntryPoint = "XSetState", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XSetState", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XSetState([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("GC")] XGC* gc, [NativeTypeName("unsigned long")] UIntPtr foreground, [NativeTypeName("unsigned long")] UIntPtr background, int function, [NativeTypeName("unsigned long")] UIntPtr plane_mask);
 
-        [DllImport(libraryPath, EntryPoint = "XSetStipple", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XSetStipple", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XSetStipple([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("GC")] XGC* gc, [NativeTypeName("Pixmap")] UIntPtr stipple);
 
-        [DllImport(libraryPath, EntryPoint = "XSetSubwindowMode", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XSetSubwindowMode", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XSetSubwindowMode([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("GC")] XGC* gc, int subwindow_mode);
 
-        [DllImport(libraryPath, EntryPoint = "XSetTSOrigin", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XSetTSOrigin", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XSetTSOrigin([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("GC")] XGC* gc, int ts_x_origin, int ts_y_origin);
 
-        [DllImport(libraryPath, EntryPoint = "XSetTile", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XSetTile", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XSetTile([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("GC")] XGC* gc, [NativeTypeName("Pixmap")] UIntPtr tile);
 
-        [DllImport(libraryPath, EntryPoint = "XSetWindowBackground", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XSetWindowBackground", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XSetWindowBackground([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Window")] UIntPtr w, [NativeTypeName("unsigned long")] UIntPtr background_pixel);
 
-        [DllImport(libraryPath, EntryPoint = "XSetWindowBackgroundPixmap", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XSetWindowBackgroundPixmap", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XSetWindowBackgroundPixmap([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Window")] UIntPtr w, [NativeTypeName("Pixmap")] UIntPtr background_pixmap);
 
-        [DllImport(libraryPath, EntryPoint = "XSetWindowBorder", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XSetWindowBorder", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XSetWindowBorder([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Window")] UIntPtr w, [NativeTypeName("unsigned long")] UIntPtr border_pixel);
 
-        [DllImport(libraryPath, EntryPoint = "XSetWindowBorderPixmap", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XSetWindowBorderPixmap", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XSetWindowBorderPixmap([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Window")] UIntPtr w, [NativeTypeName("Pixmap")] UIntPtr border_pixmap);
 
-        [DllImport(libraryPath, EntryPoint = "XSetWindowBorderWidth", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XSetWindowBorderWidth", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XSetWindowBorderWidth([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Window")] UIntPtr w, [NativeTypeName("unsigned int")] uint width);
 
-        [DllImport(libraryPath, EntryPoint = "XSetWindowColormap", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XSetWindowColormap", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XSetWindowColormap([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Window")] UIntPtr w, [NativeTypeName("Colormap")] UIntPtr colormap);
 
-        [DllImport(libraryPath, EntryPoint = "XStoreBuffer", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XStoreBuffer", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XStoreBuffer([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("const char *")] sbyte* bytes, int nbytes, int buffer);
 
-        [DllImport(libraryPath, EntryPoint = "XStoreBytes", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XStoreBytes", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XStoreBytes([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("const char *")] sbyte* bytes, int nbytes);
 
-        [DllImport(libraryPath, EntryPoint = "XStoreColor", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XStoreColor", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XStoreColor([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Colormap")] UIntPtr colormap, [NativeTypeName("XColor *")] XColor* color);
 
-        [DllImport(libraryPath, EntryPoint = "XStoreColors", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XStoreColors", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XStoreColors([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Colormap")] UIntPtr colormap, [NativeTypeName("XColor *")] XColor* color, int ncolors);
 
-        [DllImport(libraryPath, EntryPoint = "XStoreName", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XStoreName", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XStoreName([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Window")] UIntPtr w, [NativeTypeName("const char *")] sbyte* window_name);
 
-        [DllImport(libraryPath, EntryPoint = "XStoreNamedColor", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XStoreNamedColor", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XStoreNamedColor([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Colormap")] UIntPtr colormap, [NativeTypeName("const char *")] sbyte* color, [NativeTypeName("unsigned long")] UIntPtr pixel, int flags);
 
-        [DllImport(libraryPath, EntryPoint = "XSync", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XSync", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XSync([NativeTypeName("Display *")] UIntPtr display, int discard);
 
-        [DllImport(libraryPath, EntryPoint = "XTextExtents", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XTextExtents", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XTextExtents([NativeTypeName("XFontStruct *")] XFontStruct* font_struct, [NativeTypeName("const char *")] sbyte* c_string, int nchars, [NativeTypeName("int *")] int* direction_return, [NativeTypeName("int *")] int* font_ascent_return, [NativeTypeName("int *")] int* font_descent_return, [NativeTypeName("XCharStruct *")] XCharStruct* overall_return);
 
-        [DllImport(libraryPath, EntryPoint = "XTextExtents16", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XTextExtents16", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XTextExtents16([NativeTypeName("XFontStruct *")] XFontStruct* font_struct, [NativeTypeName("const XChar2b *")] XChar2b* c_string, int nchars, [NativeTypeName("int *")] int* direction_return, [NativeTypeName("int *")] int* font_ascent_return, [NativeTypeName("int *")] int* font_descent_return, [NativeTypeName("XCharStruct *")] XCharStruct* overall_return);
 
-        [DllImport(libraryPath, EntryPoint = "XTextWidth", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XTextWidth", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XTextWidth([NativeTypeName("XFontStruct *")] XFontStruct* font_struct, [NativeTypeName("const char *")] sbyte* c_string, int count);
 
-        [DllImport(libraryPath, EntryPoint = "XTextWidth16", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XTextWidth16", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XTextWidth16([NativeTypeName("XFontStruct *")] XFontStruct* font_struct, [NativeTypeName("const XChar2b *")] XChar2b* c_string, int count);
 
-        [DllImport(libraryPath, EntryPoint = "XTranslateCoordinates", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XTranslateCoordinates", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XTranslateCoordinates([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Window")] UIntPtr src_w, [NativeTypeName("Window")] UIntPtr dest_w, int src_x, int src_y, [NativeTypeName("int *")] int* dest_x_return, [NativeTypeName("int *")] int* dest_y_return, [NativeTypeName("Window *")] UIntPtr* child_return);
 
-        [DllImport(libraryPath, EntryPoint = "XUndefineCursor", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XUndefineCursor", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XUndefineCursor([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Window")] UIntPtr w);
 
-        [DllImport(libraryPath, EntryPoint = "XUngrabButton", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XUngrabButton", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XUngrabButton([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("unsigned int")] uint button, [NativeTypeName("unsigned int")] uint modifiers, [NativeTypeName("Window")] UIntPtr grab_window);
 
-        [DllImport(libraryPath, EntryPoint = "XUngrabKey", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XUngrabKey", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XUngrabKey([NativeTypeName("Display *")] UIntPtr display, int keycode, [NativeTypeName("unsigned int")] uint modifiers, [NativeTypeName("Window")] UIntPtr grab_window);
 
-        [DllImport(libraryPath, EntryPoint = "XUngrabKeyboard", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XUngrabKeyboard", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XUngrabKeyboard([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Time")] UIntPtr time);
 
-        [DllImport(libraryPath, EntryPoint = "XUngrabPointer", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XUngrabPointer", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XUngrabPointer([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Time")] UIntPtr time);
 
-        [DllImport(libraryPath, EntryPoint = "XUngrabServer", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XUngrabServer", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XUngrabServer([NativeTypeName("Display *")] UIntPtr display);
 
-        [DllImport(libraryPath, EntryPoint = "XUninstallColormap", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XUninstallColormap", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XUninstallColormap([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Colormap")] UIntPtr colormap);
 
-        [DllImport(libraryPath, EntryPoint = "XUnloadFont", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XUnloadFont", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XUnloadFont([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Font")] UIntPtr font);
 
-        [DllImport(libraryPath, EntryPoint = "XUnmapSubwindows", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XUnmapSubwindows", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XUnmapSubwindows([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Window")] UIntPtr w);
 
-        [DllImport(libraryPath, EntryPoint = "XUnmapWindow", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XUnmapWindow", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XUnmapWindow([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Window")] UIntPtr w);
 
-        [DllImport(libraryPath, EntryPoint = "XVendorRelease", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XVendorRelease", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XVendorRelease([NativeTypeName("Display *")] UIntPtr display);
 
-        [DllImport(libraryPath, EntryPoint = "XWarpPointer", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XWarpPointer", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XWarpPointer([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Window")] UIntPtr src_w, [NativeTypeName("Window")] UIntPtr dest_w, int src_x, int src_y, [NativeTypeName("unsigned int")] uint src_width, [NativeTypeName("unsigned int")] uint src_height, int dest_x, int dest_y);
 
-        [DllImport(libraryPath, EntryPoint = "XWidthMMOfScreen", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XWidthMMOfScreen", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XWidthMMOfScreen([NativeTypeName("Screen *")] Screen* screen);
 
-        [DllImport(libraryPath, EntryPoint = "XWidthOfScreen", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XWidthOfScreen", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XWidthOfScreen([NativeTypeName("Screen *")] Screen* screen);
 
-        [DllImport(libraryPath, EntryPoint = "XWindowEvent", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XWindowEvent", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XWindowEvent([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Window")] UIntPtr w, [NativeTypeName("long")] IntPtr event_mask, [NativeTypeName("XEvent *")] XEvent* event_return);
 
-        [DllImport(libraryPath, EntryPoint = "XWriteBitmapFile", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XWriteBitmapFile", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XWriteBitmapFile([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("const char *")] sbyte* filename, [NativeTypeName("Pixmap")] UIntPtr bitmap, [NativeTypeName("unsigned int")] uint width, [NativeTypeName("unsigned int")] uint height, int x_hot, int y_hot);
 
-        [DllImport(libraryPath, EntryPoint = "XSupportsLocale", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XSupportsLocale", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XSupportsLocale();
 
-        [DllImport(libraryPath, EntryPoint = "XSetLocaleModifiers", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XSetLocaleModifiers", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("char *")]
         public static extern sbyte* XSetLocaleModifiers([NativeTypeName("const char *")] sbyte* modifier_list);
 
-        [DllImport(libraryPath, EntryPoint = "XOpenOM", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XOpenOM", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("XOM")]
         public static extern XOM* XOpenOM([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("struct XrmHashBucketRec *")] XrmHashBucketRec* rdb, [NativeTypeName("const char *")] sbyte* res_name, [NativeTypeName("const char *")] sbyte* res_class);
 
-        [DllImport(libraryPath, EntryPoint = "XCloseOM", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XCloseOM", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XCloseOM([NativeTypeName("XOM")] XOM* om);
 
-        [DllImport(libraryPath, EntryPoint = "XSetOMValues", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XSetOMValues", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("char *")]
         public static extern sbyte* XSetOMValues([NativeTypeName("XOM")] XOM* om);
 
-        [DllImport(libraryPath, EntryPoint = "XGetOMValues", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XGetOMValues", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("char *")]
         public static extern sbyte* XGetOMValues([NativeTypeName("XOM")] XOM* om);
 
-        [DllImport(libraryPath, EntryPoint = "XDisplayOfOM", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XDisplayOfOM", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("Display *")]
         public static extern UIntPtr XDisplayOfOM([NativeTypeName("XOM")] XOM* om);
 
-        [DllImport(libraryPath, EntryPoint = "XLocaleOfOM", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XLocaleOfOM", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("char *")]
         public static extern sbyte* XLocaleOfOM([NativeTypeName("XOM")] XOM* om);
 
-        [DllImport(libraryPath, EntryPoint = "XCreateOC", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XCreateOC", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("XOC")]
         public static extern XOC* XCreateOC([NativeTypeName("XOM")] XOM* om);
 
-        [DllImport(libraryPath, EntryPoint = "XDestroyOC", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XDestroyOC", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void XDestroyOC([NativeTypeName("XOC")] XOC* oc);
 
-        [DllImport(libraryPath, EntryPoint = "XOMOfOC", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XOMOfOC", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("XOM")]
         public static extern XOM* XOMOfOC([NativeTypeName("XOC")] XOC* oc);
 
-        [DllImport(libraryPath, EntryPoint = "XSetOCValues", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XSetOCValues", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("char *")]
         public static extern sbyte* XSetOCValues([NativeTypeName("XOC")] XOC* oc);
 
-        [DllImport(libraryPath, EntryPoint = "XGetOCValues", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XGetOCValues", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("char *")]
         public static extern sbyte* XGetOCValues([NativeTypeName("XOC")] XOC* oc);
 
-        [DllImport(libraryPath, EntryPoint = "XCreateFontSet", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XCreateFontSet", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("XFontSet")]
         public static extern XOC* XCreateFontSet([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("const char *")] sbyte* base_font_name_list, [NativeTypeName("char ***")] sbyte*** missing_charset_list, [NativeTypeName("int *")] int* missing_charset_count, [NativeTypeName("char **")] sbyte** def_string);
 
-        [DllImport(libraryPath, EntryPoint = "XFreeFontSet", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XFreeFontSet", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void XFreeFontSet([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("XFontSet")] XOC* font_set);
 
-        [DllImport(libraryPath, EntryPoint = "XFontsOfFontSet", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XFontsOfFontSet", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XFontsOfFontSet([NativeTypeName("XFontSet")] XOC* font_set, [NativeTypeName("XFontStruct ***")] XFontStruct*** font_struct_list, [NativeTypeName("char ***")] sbyte*** font_name_list);
 
-        [DllImport(libraryPath, EntryPoint = "XBaseFontNameListOfFontSet", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XBaseFontNameListOfFontSet", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("char *")]
         public static extern sbyte* XBaseFontNameListOfFontSet([NativeTypeName("XFontSet")] XOC* font_set);
 
-        [DllImport(libraryPath, EntryPoint = "XLocaleOfFontSet", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XLocaleOfFontSet", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("char *")]
         public static extern sbyte* XLocaleOfFontSet([NativeTypeName("XFontSet")] XOC* font_set);
 
-        [DllImport(libraryPath, EntryPoint = "XContextDependentDrawing", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XContextDependentDrawing", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XContextDependentDrawing([NativeTypeName("XFontSet")] XOC* font_set);
 
-        [DllImport(libraryPath, EntryPoint = "XDirectionalDependentDrawing", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XDirectionalDependentDrawing", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XDirectionalDependentDrawing([NativeTypeName("XFontSet")] XOC* font_set);
 
-        [DllImport(libraryPath, EntryPoint = "XContextualDrawing", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XContextualDrawing", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XContextualDrawing([NativeTypeName("XFontSet")] XOC* font_set);
 
-        [DllImport(libraryPath, EntryPoint = "XExtentsOfFontSet", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XExtentsOfFontSet", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("XFontSetExtents *")]
         public static extern XFontSetExtents* XExtentsOfFontSet([NativeTypeName("XFontSet")] XOC* font_set);
 
-        [DllImport(libraryPath, EntryPoint = "XmbTextEscapement", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XmbTextEscapement", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XmbTextEscapement([NativeTypeName("XFontSet")] XOC* font_set, [NativeTypeName("const char *")] sbyte* text, int bytes_text);
 
-        [DllImport(libraryPath, EntryPoint = "XwcTextEscapement", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XwcTextEscapement", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XwcTextEscapement([NativeTypeName("XFontSet")] XOC* font_set, [NativeTypeName("const wchar_t *")] int* text, int num_wchars);
 
-        [DllImport(libraryPath, EntryPoint = "Xutf8TextEscapement", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "Xutf8TextEscapement", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int Xutf8TextEscapement([NativeTypeName("XFontSet")] XOC* font_set, [NativeTypeName("const char *")] sbyte* text, int bytes_text);
 
-        [DllImport(libraryPath, EntryPoint = "XmbTextExtents", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XmbTextExtents", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XmbTextExtents([NativeTypeName("XFontSet")] XOC* font_set, [NativeTypeName("const char *")] sbyte* text, int bytes_text, [NativeTypeName("XRectangle *")] XRectangle* overall_ink_return, [NativeTypeName("XRectangle *")] XRectangle* overall_logical_return);
 
-        [DllImport(libraryPath, EntryPoint = "XwcTextExtents", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XwcTextExtents", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XwcTextExtents([NativeTypeName("XFontSet")] XOC* font_set, [NativeTypeName("const wchar_t *")] int* text, int num_wchars, [NativeTypeName("XRectangle *")] XRectangle* overall_ink_return, [NativeTypeName("XRectangle *")] XRectangle* overall_logical_return);
 
-        [DllImport(libraryPath, EntryPoint = "Xutf8TextExtents", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "Xutf8TextExtents", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int Xutf8TextExtents([NativeTypeName("XFontSet")] XOC* font_set, [NativeTypeName("const char *")] sbyte* text, int bytes_text, [NativeTypeName("XRectangle *")] XRectangle* overall_ink_return, [NativeTypeName("XRectangle *")] XRectangle* overall_logical_return);
 
-        [DllImport(libraryPath, EntryPoint = "XmbTextPerCharExtents", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XmbTextPerCharExtents", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XmbTextPerCharExtents([NativeTypeName("XFontSet")] XOC* font_set, [NativeTypeName("const char *")] sbyte* text, int bytes_text, [NativeTypeName("XRectangle *")] XRectangle* ink_extents_buffer, [NativeTypeName("XRectangle *")] XRectangle* logical_extents_buffer, int buffer_size, [NativeTypeName("int *")] int* num_chars, [NativeTypeName("XRectangle *")] XRectangle* overall_ink_return, [NativeTypeName("XRectangle *")] XRectangle* overall_logical_return);
 
-        [DllImport(libraryPath, EntryPoint = "XwcTextPerCharExtents", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XwcTextPerCharExtents", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XwcTextPerCharExtents([NativeTypeName("XFontSet")] XOC* font_set, [NativeTypeName("const wchar_t *")] int* text, int num_wchars, [NativeTypeName("XRectangle *")] XRectangle* ink_extents_buffer, [NativeTypeName("XRectangle *")] XRectangle* logical_extents_buffer, int buffer_size, [NativeTypeName("int *")] int* num_chars, [NativeTypeName("XRectangle *")] XRectangle* overall_ink_return, [NativeTypeName("XRectangle *")] XRectangle* overall_logical_return);
 
-        [DllImport(libraryPath, EntryPoint = "Xutf8TextPerCharExtents", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "Xutf8TextPerCharExtents", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int Xutf8TextPerCharExtents([NativeTypeName("XFontSet")] XOC* font_set, [NativeTypeName("const char *")] sbyte* text, int bytes_text, [NativeTypeName("XRectangle *")] XRectangle* ink_extents_buffer, [NativeTypeName("XRectangle *")] XRectangle* logical_extents_buffer, int buffer_size, [NativeTypeName("int *")] int* num_chars, [NativeTypeName("XRectangle *")] XRectangle* overall_ink_return, [NativeTypeName("XRectangle *")] XRectangle* overall_logical_return);
 
-        [DllImport(libraryPath, EntryPoint = "XmbDrawText", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XmbDrawText", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void XmbDrawText([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Drawable")] UIntPtr d, [NativeTypeName("GC")] XGC* gc, int x, int y, [NativeTypeName("XmbTextItem *")] XmbTextItem* text_items, int nitems);
 
-        [DllImport(libraryPath, EntryPoint = "XwcDrawText", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XwcDrawText", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void XwcDrawText([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Drawable")] UIntPtr d, [NativeTypeName("GC")] XGC* gc, int x, int y, [NativeTypeName("XwcTextItem *")] XwcTextItem* text_items, int nitems);
 
-        [DllImport(libraryPath, EntryPoint = "Xutf8DrawText", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "Xutf8DrawText", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void Xutf8DrawText([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Drawable")] UIntPtr d, [NativeTypeName("GC")] XGC* gc, int x, int y, [NativeTypeName("XmbTextItem *")] XmbTextItem* text_items, int nitems);
 
-        [DllImport(libraryPath, EntryPoint = "XmbDrawString", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XmbDrawString", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void XmbDrawString([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Drawable")] UIntPtr d, [NativeTypeName("XFontSet")] XOC* font_set, [NativeTypeName("GC")] XGC* gc, int x, int y, [NativeTypeName("const char *")] sbyte* text, int bytes_text);
 
-        [DllImport(libraryPath, EntryPoint = "XwcDrawString", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XwcDrawString", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void XwcDrawString([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Drawable")] UIntPtr d, [NativeTypeName("XFontSet")] XOC* font_set, [NativeTypeName("GC")] XGC* gc, int x, int y, [NativeTypeName("const wchar_t *")] int* text, int num_wchars);
 
-        [DllImport(libraryPath, EntryPoint = "Xutf8DrawString", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "Xutf8DrawString", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void Xutf8DrawString([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Drawable")] UIntPtr d, [NativeTypeName("XFontSet")] XOC* font_set, [NativeTypeName("GC")] XGC* gc, int x, int y, [NativeTypeName("const char *")] sbyte* text, int bytes_text);
 
-        [DllImport(libraryPath, EntryPoint = "XmbDrawImageString", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XmbDrawImageString", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void XmbDrawImageString([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Drawable")] UIntPtr d, [NativeTypeName("XFontSet")] XOC* font_set, [NativeTypeName("GC")] XGC* gc, int x, int y, [NativeTypeName("const char *")] sbyte* text, int bytes_text);
 
-        [DllImport(libraryPath, EntryPoint = "XwcDrawImageString", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XwcDrawImageString", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void XwcDrawImageString([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Drawable")] UIntPtr d, [NativeTypeName("XFontSet")] XOC* font_set, [NativeTypeName("GC")] XGC* gc, int x, int y, [NativeTypeName("const wchar_t *")] int* text, int num_wchars);
 
-        [DllImport(libraryPath, EntryPoint = "Xutf8DrawImageString", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "Xutf8DrawImageString", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void Xutf8DrawImageString([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Drawable")] UIntPtr d, [NativeTypeName("XFontSet")] XOC* font_set, [NativeTypeName("GC")] XGC* gc, int x, int y, [NativeTypeName("const char *")] sbyte* text, int bytes_text);
 
-        [DllImport(libraryPath, EntryPoint = "XOpenIM", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XOpenIM", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("XIM")]
         public static extern XIM* XOpenIM([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("struct XrmHashBucketRec *")] XrmHashBucketRec* rdb, [NativeTypeName("char *")] sbyte* res_name, [NativeTypeName("char *")] sbyte* res_class);
 
-        [DllImport(libraryPath, EntryPoint = "XCloseIM", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XCloseIM", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XCloseIM([NativeTypeName("XIM")] XIM* im);
 
-        [DllImport(libraryPath, EntryPoint = "XGetIMValues", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XGetIMValues", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("char *")]
         public static extern sbyte* XGetIMValues([NativeTypeName("XIM")] XIM* im);
 
-        [DllImport(libraryPath, EntryPoint = "XSetIMValues", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XSetIMValues", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("char *")]
         public static extern sbyte* XSetIMValues([NativeTypeName("XIM")] XIM* im);
 
-        [DllImport(libraryPath, EntryPoint = "XDisplayOfIM", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XDisplayOfIM", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("Display *")]
         public static extern UIntPtr XDisplayOfIM([NativeTypeName("XIM")] XIM* im);
 
-        [DllImport(libraryPath, EntryPoint = "XLocaleOfIM", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XLocaleOfIM", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("char *")]
         public static extern sbyte* XLocaleOfIM([NativeTypeName("XIM")] XIM* im);
 
-        [DllImport(libraryPath, EntryPoint = "XCreateIC", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XCreateIC", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("XIC")]
         public static extern XIC* XCreateIC([NativeTypeName("XIM")] XIM* im);
 
-        [DllImport(libraryPath, EntryPoint = "XDestroyIC", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XDestroyIC", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void XDestroyIC([NativeTypeName("XIC")] XIC* ic);
 
-        [DllImport(libraryPath, EntryPoint = "XSetICFocus", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XSetICFocus", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void XSetICFocus([NativeTypeName("XIC")] XIC* ic);
 
-        [DllImport(libraryPath, EntryPoint = "XUnsetICFocus", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XUnsetICFocus", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void XUnsetICFocus([NativeTypeName("XIC")] XIC* ic);
 
-        [DllImport(libraryPath, EntryPoint = "XwcResetIC", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XwcResetIC", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("wchar_t *")]
         public static extern int* XwcResetIC([NativeTypeName("XIC")] XIC* ic);
 
-        [DllImport(libraryPath, EntryPoint = "XmbResetIC", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XmbResetIC", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("char *")]
         public static extern sbyte* XmbResetIC([NativeTypeName("XIC")] XIC* ic);
 
-        [DllImport(libraryPath, EntryPoint = "Xutf8ResetIC", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "Xutf8ResetIC", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("char *")]
         public static extern sbyte* Xutf8ResetIC([NativeTypeName("XIC")] XIC* ic);
 
-        [DllImport(libraryPath, EntryPoint = "XSetICValues", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XSetICValues", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("char *")]
         public static extern sbyte* XSetICValues([NativeTypeName("XIC")] XIC* ic);
 
-        [DllImport(libraryPath, EntryPoint = "XGetICValues", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XGetICValues", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("char *")]
         public static extern sbyte* XGetICValues([NativeTypeName("XIC")] XIC* ic);
 
-        [DllImport(libraryPath, EntryPoint = "XIMOfIC", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XIMOfIC", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("XIM")]
         public static extern XIM* XIMOfIC([NativeTypeName("XIC")] XIC* ic);
 
-        [DllImport(libraryPath, EntryPoint = "XFilterEvent", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XFilterEvent", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XFilterEvent([NativeTypeName("XEvent *")] XEvent* c_event, [NativeTypeName("Window")] UIntPtr window);
 
-        [DllImport(libraryPath, EntryPoint = "XmbLookupString", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XmbLookupString", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XmbLookupString([NativeTypeName("XIC")] XIC* ic, [NativeTypeName("XKeyPressedEvent *")] XKeyEvent* c_event, [NativeTypeName("char *")] sbyte* buffer_return, int bytes_buffer, [NativeTypeName("KeySym *")] UIntPtr* keysym_return, [NativeTypeName("int *")] int* status_return);
 
-        [DllImport(libraryPath, EntryPoint = "XwcLookupString", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XwcLookupString", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XwcLookupString([NativeTypeName("XIC")] XIC* ic, [NativeTypeName("XKeyPressedEvent *")] XKeyEvent* c_event, [NativeTypeName("wchar_t *")] int* buffer_return, int wchars_buffer, [NativeTypeName("KeySym *")] UIntPtr* keysym_return, [NativeTypeName("int *")] int* status_return);
 
-        [DllImport(libraryPath, EntryPoint = "Xutf8LookupString", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "Xutf8LookupString", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int Xutf8LookupString([NativeTypeName("XIC")] XIC* ic, [NativeTypeName("XKeyPressedEvent *")] XKeyEvent* c_event, [NativeTypeName("char *")] sbyte* buffer_return, int bytes_return, [NativeTypeName("KeySym *")] UIntPtr* keysym_return, [NativeTypeName("int *")] int* status_return);
 
-        [DllImport(libraryPath, EntryPoint = "XVaCreateNestedList", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XVaCreateNestedList", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("XVaNestedList")]
         public static extern void* XVaCreateNestedList(int unused);
 
-        [DllImport(libraryPath, EntryPoint = "XRegisterIMInstantiateCallback", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XRegisterIMInstantiateCallback", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XRegisterIMInstantiateCallback([NativeTypeName("Display *")] UIntPtr dpy, [NativeTypeName("struct XrmHashBucketRec *")] XrmHashBucketRec* rdb, [NativeTypeName("char *")] sbyte* res_name, [NativeTypeName("char *")] sbyte* res_class, [NativeTypeName("XIDProc")] IntPtr callback, [NativeTypeName("XPointer")] sbyte* client_data);
 
-        [DllImport(libraryPath, EntryPoint = "XUnregisterIMInstantiateCallback", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XUnregisterIMInstantiateCallback", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XUnregisterIMInstantiateCallback([NativeTypeName("Display *")] UIntPtr dpy, [NativeTypeName("struct XrmHashBucketRec *")] XrmHashBucketRec* rdb, [NativeTypeName("char *")] sbyte* res_name, [NativeTypeName("char *")] sbyte* res_class, [NativeTypeName("XIDProc")] IntPtr callback, [NativeTypeName("XPointer")] sbyte* client_data);
 
-        [DllImport(libraryPath, EntryPoint = "XInternalConnectionNumbers", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XInternalConnectionNumbers", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XInternalConnectionNumbers([NativeTypeName("Display *")] UIntPtr dpy, [NativeTypeName("int **")] int** fd_return, [NativeTypeName("int *")] int* count_return);
 
-        [DllImport(libraryPath, EntryPoint = "XProcessInternalConnection", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XProcessInternalConnection", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void XProcessInternalConnection([NativeTypeName("Display *")] UIntPtr dpy, int fd);
 
-        [DllImport(libraryPath, EntryPoint = "XAddConnectionWatch", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XAddConnectionWatch", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XAddConnectionWatch([NativeTypeName("Display *")] UIntPtr dpy, [NativeTypeName("XConnectionWatchProc")] IntPtr callback, [NativeTypeName("XPointer")] sbyte* client_data);
 
-        [DllImport(libraryPath, EntryPoint = "XRemoveConnectionWatch", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XRemoveConnectionWatch", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void XRemoveConnectionWatch([NativeTypeName("Display *")] UIntPtr dpy, [NativeTypeName("XConnectionWatchProc")] IntPtr callback, [NativeTypeName("XPointer")] sbyte* client_data);
 
-        [DllImport(libraryPath, EntryPoint = "XSetAuthorization", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XSetAuthorization", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void XSetAuthorization([NativeTypeName("char *")] sbyte* name, int namelen, [NativeTypeName("char *")] sbyte* data, int datalen);
 
-        [DllImport(libraryPath, EntryPoint = "_Xmbtowc", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "_Xmbtowc", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int _Xmbtowc([NativeTypeName("wchar_t *")] int* wstr, [NativeTypeName("char *")] sbyte* str, int len);
 
-        [DllImport(libraryPath, EntryPoint = "_Xwctomb", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "_Xwctomb", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int _Xwctomb([NativeTypeName("char *")] sbyte* str, [NativeTypeName("wchar_t")] int wc);
 
-        [DllImport(libraryPath, EntryPoint = "XGetEventData", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XGetEventData", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XGetEventData([NativeTypeName("Display *")] UIntPtr dpy, [NativeTypeName("XGenericEventCookie *")] XGenericEventCookie* cookie);
 
-        [DllImport(libraryPath, EntryPoint = "XFreeEventData", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XFreeEventData", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void XFreeEventData([NativeTypeName("Display *")] UIntPtr dpy, [NativeTypeName("XGenericEventCookie *")] XGenericEventCookie* cookie);
     }
 }

--- a/sources/Interop/Xlib/Xresource/Xlib.cs
+++ b/sources/Interop/Xlib/Xresource/Xlib.cs
@@ -10,97 +10,97 @@ namespace TerraFX.Interop
 {
     public static unsafe partial class Xlib
     {
-        [DllImport(libraryPath, EntryPoint = "Xpermalloc", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "Xpermalloc", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("char *")]
         public static extern sbyte* Xpermalloc([NativeTypeName("unsigned int")] uint size);
 
-        [DllImport(libraryPath, EntryPoint = "XrmStringToQuark", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XrmStringToQuark", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("XrmQuark")]
         public static extern int XrmStringToQuark([NativeTypeName("const char *")] sbyte* c_string);
 
-        [DllImport(libraryPath, EntryPoint = "XrmPermStringToQuark", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XrmPermStringToQuark", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("XrmQuark")]
         public static extern int XrmPermStringToQuark([NativeTypeName("const char *")] sbyte* c_string);
 
-        [DllImport(libraryPath, EntryPoint = "XrmQuarkToString", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XrmQuarkToString", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("XrmString")]
         public static extern sbyte* XrmQuarkToString([NativeTypeName("XrmQuark")] int quark);
 
-        [DllImport(libraryPath, EntryPoint = "XrmUniqueQuark", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XrmUniqueQuark", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("XrmQuark")]
         public static extern int XrmUniqueQuark();
 
-        [DllImport(libraryPath, EntryPoint = "XrmStringToQuarkList", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XrmStringToQuarkList", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void XrmStringToQuarkList([NativeTypeName("const char *")] sbyte* c_string, [NativeTypeName("XrmQuarkList")] int* quarks_return);
 
-        [DllImport(libraryPath, EntryPoint = "XrmStringToBindingQuarkList", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XrmStringToBindingQuarkList", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void XrmStringToBindingQuarkList([NativeTypeName("const char *")] sbyte* c_string, [NativeTypeName("XrmBindingList")] XrmBinding* bindings_return, [NativeTypeName("XrmQuarkList")] int* quarks_return);
 
-        [DllImport(libraryPath, EntryPoint = "XrmDestroyDatabase", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XrmDestroyDatabase", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void XrmDestroyDatabase([NativeTypeName("XrmDatabase")] XrmHashBucketRec* database);
 
-        [DllImport(libraryPath, EntryPoint = "XrmQPutResource", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XrmQPutResource", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void XrmQPutResource([NativeTypeName("XrmDatabase *")] XrmHashBucketRec** database, [NativeTypeName("XrmBindingList")] XrmBinding* bindings, [NativeTypeName("XrmQuarkList")] int* quarks, [NativeTypeName("XrmRepresentation")] int type, [NativeTypeName("XrmValue *")] XrmValue* value);
 
-        [DllImport(libraryPath, EntryPoint = "XrmPutResource", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XrmPutResource", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void XrmPutResource([NativeTypeName("XrmDatabase *")] XrmHashBucketRec** database, [NativeTypeName("const char *")] sbyte* specifier, [NativeTypeName("const char *")] sbyte* type, [NativeTypeName("XrmValue *")] XrmValue* value);
 
-        [DllImport(libraryPath, EntryPoint = "XrmQPutStringResource", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XrmQPutStringResource", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void XrmQPutStringResource([NativeTypeName("XrmDatabase *")] XrmHashBucketRec** database, [NativeTypeName("XrmBindingList")] XrmBinding* bindings, [NativeTypeName("XrmQuarkList")] int* quarks, [NativeTypeName("const char *")] sbyte* value);
 
-        [DllImport(libraryPath, EntryPoint = "XrmPutStringResource", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XrmPutStringResource", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void XrmPutStringResource([NativeTypeName("XrmDatabase *")] XrmHashBucketRec** database, [NativeTypeName("const char *")] sbyte* specifier, [NativeTypeName("const char *")] sbyte* value);
 
-        [DllImport(libraryPath, EntryPoint = "XrmPutLineResource", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XrmPutLineResource", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void XrmPutLineResource([NativeTypeName("XrmDatabase *")] XrmHashBucketRec** database, [NativeTypeName("const char *")] sbyte* line);
 
-        [DllImport(libraryPath, EntryPoint = "XrmQGetResource", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XrmQGetResource", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XrmQGetResource([NativeTypeName("XrmDatabase")] XrmHashBucketRec* database, [NativeTypeName("XrmNameList")] int* quark_name, [NativeTypeName("XrmClassList")] int* quark_class, [NativeTypeName("XrmRepresentation *")] int* quark_type_return, [NativeTypeName("XrmValue *")] XrmValue* value_return);
 
-        [DllImport(libraryPath, EntryPoint = "XrmGetResource", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XrmGetResource", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XrmGetResource([NativeTypeName("XrmDatabase")] XrmHashBucketRec* database, [NativeTypeName("const char *")] sbyte* str_name, [NativeTypeName("const char *")] sbyte* str_class, [NativeTypeName("char **")] sbyte** str_type_return, [NativeTypeName("XrmValue *")] XrmValue* value_return);
 
-        [DllImport(libraryPath, EntryPoint = "XrmQGetSearchList", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XrmQGetSearchList", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XrmQGetSearchList([NativeTypeName("XrmDatabase")] XrmHashBucketRec* database, [NativeTypeName("XrmNameList")] int* names, [NativeTypeName("XrmClassList")] int* classes, [NativeTypeName("XrmSearchList")] XrmHashBucketRec** list_return, int list_length);
 
-        [DllImport(libraryPath, EntryPoint = "XrmQGetSearchResource", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XrmQGetSearchResource", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XrmQGetSearchResource([NativeTypeName("XrmSearchList")] XrmHashBucketRec** list, [NativeTypeName("XrmName")] int name, [NativeTypeName("XrmClass")] int c_class, [NativeTypeName("XrmRepresentation *")] int* type_return, [NativeTypeName("XrmValue *")] XrmValue* value_return);
 
-        [DllImport(libraryPath, EntryPoint = "XrmSetDatabase", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XrmSetDatabase", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void XrmSetDatabase([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("XrmDatabase")] XrmHashBucketRec* database);
 
-        [DllImport(libraryPath, EntryPoint = "XrmGetDatabase", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XrmGetDatabase", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("XrmDatabase")]
         public static extern XrmHashBucketRec* XrmGetDatabase([NativeTypeName("Display *")] UIntPtr display);
 
-        [DllImport(libraryPath, EntryPoint = "XrmGetFileDatabase", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XrmGetFileDatabase", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("XrmDatabase")]
         public static extern XrmHashBucketRec* XrmGetFileDatabase([NativeTypeName("const char *")] sbyte* filename);
 
-        [DllImport(libraryPath, EntryPoint = "XrmCombineFileDatabase", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XrmCombineFileDatabase", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XrmCombineFileDatabase([NativeTypeName("const char *")] sbyte* filename, [NativeTypeName("XrmDatabase *")] XrmHashBucketRec** target, int c_override);
 
-        [DllImport(libraryPath, EntryPoint = "XrmGetStringDatabase", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XrmGetStringDatabase", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("XrmDatabase")]
         public static extern XrmHashBucketRec* XrmGetStringDatabase([NativeTypeName("const char *")] sbyte* data);
 
-        [DllImport(libraryPath, EntryPoint = "XrmPutFileDatabase", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XrmPutFileDatabase", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void XrmPutFileDatabase([NativeTypeName("XrmDatabase")] XrmHashBucketRec* database, [NativeTypeName("const char *")] sbyte* filename);
 
-        [DllImport(libraryPath, EntryPoint = "XrmMergeDatabases", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XrmMergeDatabases", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void XrmMergeDatabases([NativeTypeName("XrmDatabase")] XrmHashBucketRec* source_db, [NativeTypeName("XrmDatabase *")] XrmHashBucketRec** target_db);
 
-        [DllImport(libraryPath, EntryPoint = "XrmCombineDatabase", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XrmCombineDatabase", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void XrmCombineDatabase([NativeTypeName("XrmDatabase")] XrmHashBucketRec* source_db, [NativeTypeName("XrmDatabase *")] XrmHashBucketRec** target_db, int c_override);
 
-        [DllImport(libraryPath, EntryPoint = "XrmEnumerateDatabase", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XrmEnumerateDatabase", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XrmEnumerateDatabase([NativeTypeName("XrmDatabase")] XrmHashBucketRec* db, [NativeTypeName("XrmNameList")] int* name_prefix, [NativeTypeName("XrmClassList")] int* class_prefix, int mode, [NativeTypeName("int (*)(XrmDatabase *, XrmBindingList, XrmQuarkList, XrmRepresentation *, XrmValue *, XPointer)")] IntPtr proc, [NativeTypeName("XPointer")] sbyte* closure);
 
-        [DllImport(libraryPath, EntryPoint = "XrmLocaleOfDatabase", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XrmLocaleOfDatabase", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("const char *")]
         public static extern sbyte* XrmLocaleOfDatabase([NativeTypeName("XrmDatabase")] XrmHashBucketRec* database);
 
-        [DllImport(libraryPath, EntryPoint = "XrmParseCommand", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XrmParseCommand", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void XrmParseCommand([NativeTypeName("XrmDatabase *")] XrmHashBucketRec** database, [NativeTypeName("XrmOptionDescList")] XrmOptionDescRec* table, int table_count, [NativeTypeName("const char *")] sbyte* name, [NativeTypeName("int *")] int* argc_in_out, [NativeTypeName("char **")] sbyte** argv_in_out);
     }
 }

--- a/sources/Interop/Xlib/Xutil/Xlib.cs
+++ b/sources/Interop/Xlib/Xutil/Xlib.cs
@@ -10,244 +10,244 @@ namespace TerraFX.Interop
 {
     public static unsafe partial class Xlib
     {
-        [DllImport(libraryPath, EntryPoint = "XDestroyImage", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XDestroyImage", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XDestroyImage([NativeTypeName("XImage *")] XImage* ximage);
 
-        [DllImport(libraryPath, EntryPoint = "XDestroyImage", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XDestroyImage", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("unsigned long")]
         public static extern UIntPtr XGetPixel([NativeTypeName("XImage *")] XImage* ximage, int x, int y);
 
-        [DllImport(libraryPath, EntryPoint = "XPutPixel", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XPutPixel", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XPutPixel([NativeTypeName("XImage *")] XImage* ximage, int x, int y, [NativeTypeName("unsigned long")] UIntPtr pixel);
 
-        [DllImport(libraryPath, EntryPoint = "XSubImage", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XSubImage", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("XImage *")]
         public static extern XImage* XSubImage([NativeTypeName("XImage *")] XImage* ximage, int x, int y, [NativeTypeName("unsigned int")] uint width, [NativeTypeName("unsigned int")] uint height);
 
-        [DllImport(libraryPath, EntryPoint = "XAddPixel", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XAddPixel", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XAddPixel([NativeTypeName("XImage *")] XImage* ximage, [NativeTypeName("long")] IntPtr value);
 
-        [DllImport(libraryPath, EntryPoint = "XAllocClassHint", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XAllocClassHint", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("XClassHint *")]
         public static extern XClassHint* XAllocClassHint();
 
-        [DllImport(libraryPath, EntryPoint = "XAllocIconSize", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XAllocIconSize", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("XIconSize *")]
         public static extern XIconSize* XAllocIconSize();
 
-        [DllImport(libraryPath, EntryPoint = "XAllocSizeHints", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XAllocSizeHints", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("XSizeHints *")]
         public static extern XSizeHints* XAllocSizeHints();
 
-        [DllImport(libraryPath, EntryPoint = "XAllocStandardColormap", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XAllocStandardColormap", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("XStandardColormap *")]
         public static extern XStandardColormap* XAllocStandardColormap();
 
-        [DllImport(libraryPath, EntryPoint = "XAllocWMHints", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XAllocWMHints", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("XWMHints *")]
         public static extern XWMHints* XAllocWMHints();
 
-        [DllImport(libraryPath, EntryPoint = "XClipBox", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XClipBox", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XClipBox([NativeTypeName("Region")] XRegion* r, [NativeTypeName("XRectangle *")] XRectangle* rect_return);
 
-        [DllImport(libraryPath, EntryPoint = "XCreateRegion", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XCreateRegion", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("Region")]
         public static extern XRegion* XCreateRegion();
 
-        [DllImport(libraryPath, EntryPoint = "XDefaultString", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XDefaultString", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("const char *")]
         public static extern sbyte* XDefaultString();
 
-        [DllImport(libraryPath, EntryPoint = "XDeleteContext", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XDeleteContext", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XDeleteContext([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("XID")] UIntPtr rid, [NativeTypeName("XContext")] int context);
 
-        [DllImport(libraryPath, EntryPoint = "XDestroyRegion", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XDestroyRegion", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XDestroyRegion([NativeTypeName("Region")] XRegion* r);
 
-        [DllImport(libraryPath, EntryPoint = "XEmptyRegion", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XEmptyRegion", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XEmptyRegion([NativeTypeName("Region")] XRegion* r);
 
-        [DllImport(libraryPath, EntryPoint = "XEqualRegion", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XEqualRegion", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XEqualRegion([NativeTypeName("Region")] XRegion* r1, [NativeTypeName("Region")] XRegion* r2);
 
-        [DllImport(libraryPath, EntryPoint = "XFindContext", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XFindContext", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XFindContext([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("XID")] UIntPtr rid, [NativeTypeName("XContext")] int context, [NativeTypeName("XPointer *")] sbyte** data_return);
 
-        [DllImport(libraryPath, EntryPoint = "XGetClassHint", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XGetClassHint", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XGetClassHint([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Window")] UIntPtr w, [NativeTypeName("XClassHint *")] XClassHint* class_hints_return);
 
-        [DllImport(libraryPath, EntryPoint = "XGetIconSizes", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XGetIconSizes", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XGetIconSizes([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Window")] UIntPtr w, [NativeTypeName("XIconSize **")] XIconSize** size_list_return, [NativeTypeName("int *")] int* count_return);
 
-        [DllImport(libraryPath, EntryPoint = "XGetNormalHints", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XGetNormalHints", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XGetNormalHints([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Window")] UIntPtr w, [NativeTypeName("XSizeHints *")] XSizeHints* hints_return);
 
-        [DllImport(libraryPath, EntryPoint = "XGetRGBColormaps", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XGetRGBColormaps", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XGetRGBColormaps([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Window")] UIntPtr w, [NativeTypeName("XStandardColormap **")] XStandardColormap** stdcmap_return, [NativeTypeName("int *")] int* count_return, [NativeTypeName("Atom")] UIntPtr property);
 
-        [DllImport(libraryPath, EntryPoint = "XGetSizeHints", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XGetSizeHints", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XGetSizeHints([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Window")] UIntPtr w, [NativeTypeName("XSizeHints *")] XSizeHints* hints_return, [NativeTypeName("Atom")] UIntPtr property);
 
-        [DllImport(libraryPath, EntryPoint = "XGetStandardColormap", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XGetStandardColormap", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XGetStandardColormap([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Window")] UIntPtr w, [NativeTypeName("XStandardColormap *")] XStandardColormap* colormap_return, [NativeTypeName("Atom")] UIntPtr property);
 
-        [DllImport(libraryPath, EntryPoint = "XGetTextProperty", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XGetTextProperty", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XGetTextProperty([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Window")] UIntPtr window, [NativeTypeName("XTextProperty *")] XTextProperty* text_prop_return, [NativeTypeName("Atom")] UIntPtr property);
 
-        [DllImport(libraryPath, EntryPoint = "XGetVisualInfo", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XGetVisualInfo", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("XVisualInfo *")]
         public static extern XVisualInfo* XGetVisualInfo([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("long")] IntPtr vinfo_mask, [NativeTypeName("XVisualInfo *")] XVisualInfo* vinfo_template, [NativeTypeName("int *")] int* nitems_return);
 
-        [DllImport(libraryPath, EntryPoint = "XGetWMClientMachine", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XGetWMClientMachine", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XGetWMClientMachine([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Window")] UIntPtr w, [NativeTypeName("XTextProperty *")] XTextProperty* text_prop_return);
 
-        [DllImport(libraryPath, EntryPoint = "XGetWMHints", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XGetWMHints", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("XWMHints *")]
         public static extern XWMHints* XGetWMHints([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Window")] UIntPtr w);
 
-        [DllImport(libraryPath, EntryPoint = "XGetWMIconName", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XGetWMIconName", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XGetWMIconName([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Window")] UIntPtr w, [NativeTypeName("XTextProperty *")] XTextProperty* text_prop_return);
 
-        [DllImport(libraryPath, EntryPoint = "XGetWMName", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XGetWMName", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XGetWMName([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Window")] UIntPtr w, [NativeTypeName("XTextProperty *")] XTextProperty* text_prop_return);
 
-        [DllImport(libraryPath, EntryPoint = "XGetWMNormalHints", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XGetWMNormalHints", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XGetWMNormalHints([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Window")] UIntPtr w, [NativeTypeName("XSizeHints *")] XSizeHints* hints_return, [NativeTypeName("long *")] IntPtr* supplied_return);
 
-        [DllImport(libraryPath, EntryPoint = "XGetWMSizeHints", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XGetWMSizeHints", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XGetWMSizeHints([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Window")] UIntPtr w, [NativeTypeName("XSizeHints *")] XSizeHints* hints_return, [NativeTypeName("long *")] IntPtr* supplied_return, [NativeTypeName("Atom")] UIntPtr property);
 
-        [DllImport(libraryPath, EntryPoint = "XGetZoomHints", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XGetZoomHints", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XGetZoomHints([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Window")] UIntPtr w, [NativeTypeName("XSizeHints *")] XSizeHints* zhints_return);
 
-        [DllImport(libraryPath, EntryPoint = "XIntersectRegion", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XIntersectRegion", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XIntersectRegion([NativeTypeName("Region")] XRegion* sra, [NativeTypeName("Region")] XRegion* srb, [NativeTypeName("Region")] XRegion* dr_return);
 
-        [DllImport(libraryPath, EntryPoint = "XConvertCase", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XConvertCase", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void XConvertCase([NativeTypeName("KeySym")] UIntPtr sym, [NativeTypeName("KeySym *")] UIntPtr* lower, [NativeTypeName("KeySym *")] UIntPtr* upper);
 
-        [DllImport(libraryPath, EntryPoint = "XLookupString", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XLookupString", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XLookupString([NativeTypeName("XKeyEvent *")] XKeyEvent* event_struct, [NativeTypeName("char *")] sbyte* buffer_return, int bytes_buffer, [NativeTypeName("KeySym *")] UIntPtr* keysym_return, [NativeTypeName("XComposeStatus *")] XComposeStatus* status_in_out);
 
-        [DllImport(libraryPath, EntryPoint = "XMatchVisualInfo", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XMatchVisualInfo", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XMatchVisualInfo([NativeTypeName("Display *")] UIntPtr display, int screen, int depth, int c_class, [NativeTypeName("XVisualInfo *")] XVisualInfo* vinfo_return);
 
-        [DllImport(libraryPath, EntryPoint = "XOffsetRegion", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XOffsetRegion", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XOffsetRegion([NativeTypeName("Region")] XRegion* r, int dx, int dy);
 
-        [DllImport(libraryPath, EntryPoint = "XPointInRegion", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XPointInRegion", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XPointInRegion([NativeTypeName("Region")] XRegion* r, int x, int y);
 
-        [DllImport(libraryPath, EntryPoint = "XPolygonRegion", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XPolygonRegion", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("Region")]
         public static extern XRegion* XPolygonRegion([NativeTypeName("XPoint *")] XPoint* points, int n, int fill_rule);
 
-        [DllImport(libraryPath, EntryPoint = "XRectInRegion", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XRectInRegion", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XRectInRegion([NativeTypeName("Region")] XRegion* r, int x, int y, [NativeTypeName("unsigned int")] uint width, [NativeTypeName("unsigned int")] uint height);
 
-        [DllImport(libraryPath, EntryPoint = "XSaveContext", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XSaveContext", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XSaveContext([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("XID")] UIntPtr rid, [NativeTypeName("XContext")] int context, [NativeTypeName("const char *")] sbyte* data);
 
-        [DllImport(libraryPath, EntryPoint = "XSetClassHint", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XSetClassHint", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XSetClassHint([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Window")] UIntPtr w, [NativeTypeName("XClassHint *")] XClassHint* class_hints);
 
-        [DllImport(libraryPath, EntryPoint = "XSetIconSizes", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XSetIconSizes", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XSetIconSizes([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Window")] UIntPtr w, [NativeTypeName("XIconSize *")] XIconSize* size_list, int count);
 
-        [DllImport(libraryPath, EntryPoint = "XSetNormalHints", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XSetNormalHints", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XSetNormalHints([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Window")] UIntPtr w, [NativeTypeName("XSizeHints *")] XSizeHints* hints);
 
-        [DllImport(libraryPath, EntryPoint = "XSetRGBColormaps", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XSetRGBColormaps", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void XSetRGBColormaps([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Window")] UIntPtr w, [NativeTypeName("XStandardColormap *")] XStandardColormap* stdcmaps, int count, [NativeTypeName("Atom")] UIntPtr property);
 
-        [DllImport(libraryPath, EntryPoint = "XSetSizeHints", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XSetSizeHints", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XSetSizeHints([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Window")] UIntPtr w, [NativeTypeName("XSizeHints *")] XSizeHints* hints, [NativeTypeName("Atom")] UIntPtr property);
 
-        [DllImport(libraryPath, EntryPoint = "XSetStandardProperties", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XSetStandardProperties", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XSetStandardProperties([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Window")] UIntPtr w, [NativeTypeName("const char *")] sbyte* window_name, [NativeTypeName("const char *")] sbyte* icon_name, [NativeTypeName("Pixmap")] UIntPtr icon_pixmap, [NativeTypeName("char **")] sbyte** argv, int argc, [NativeTypeName("XSizeHints *")] XSizeHints* hints);
 
-        [DllImport(libraryPath, EntryPoint = "XSetTextProperty", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XSetTextProperty", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void XSetTextProperty([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Window")] UIntPtr w, [NativeTypeName("XTextProperty *")] XTextProperty* text_prop, [NativeTypeName("Atom")] UIntPtr property);
 
-        [DllImport(libraryPath, EntryPoint = "XSetWMClientMachine", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XSetWMClientMachine", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void XSetWMClientMachine([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Window")] UIntPtr w, [NativeTypeName("XTextProperty *")] XTextProperty* text_prop);
 
-        [DllImport(libraryPath, EntryPoint = "XSetWMHints", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XSetWMHints", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XSetWMHints([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Window")] UIntPtr w, [NativeTypeName("XWMHints *")] XWMHints* wm_hints);
 
-        [DllImport(libraryPath, EntryPoint = "XSetWMIconName", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XSetWMIconName", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void XSetWMIconName([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Window")] UIntPtr w, [NativeTypeName("XTextProperty *")] XTextProperty* text_prop);
 
-        [DllImport(libraryPath, EntryPoint = "XSetWMName", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XSetWMName", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void XSetWMName([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Window")] UIntPtr w, [NativeTypeName("XTextProperty *")] XTextProperty* text_prop);
 
-        [DllImport(libraryPath, EntryPoint = "XSetWMNormalHints", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XSetWMNormalHints", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void XSetWMNormalHints([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Window")] UIntPtr w, [NativeTypeName("XSizeHints *")] XSizeHints* hints);
 
-        [DllImport(libraryPath, EntryPoint = "XSetWMProperties", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XSetWMProperties", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void XSetWMProperties([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Window")] UIntPtr w, [NativeTypeName("XTextProperty *")] XTextProperty* window_name, [NativeTypeName("XTextProperty *")] XTextProperty* icon_name, [NativeTypeName("char **")] sbyte** argv, int argc, [NativeTypeName("XSizeHints *")] XSizeHints* normal_hints, [NativeTypeName("XWMHints *")] XWMHints* wm_hints, [NativeTypeName("XClassHint *")] XClassHint* class_hints);
 
-        [DllImport(libraryPath, EntryPoint = "XmbSetWMProperties", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XmbSetWMProperties", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void XmbSetWMProperties([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Window")] UIntPtr w, [NativeTypeName("const char *")] sbyte* window_name, [NativeTypeName("const char *")] sbyte* icon_name, [NativeTypeName("char **")] sbyte** argv, int argc, [NativeTypeName("XSizeHints *")] XSizeHints* normal_hints, [NativeTypeName("XWMHints *")] XWMHints* wm_hints, [NativeTypeName("XClassHint *")] XClassHint* class_hints);
 
-        [DllImport(libraryPath, EntryPoint = "Xutf8SetWMProperties", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "Xutf8SetWMProperties", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void Xutf8SetWMProperties([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Window")] UIntPtr w, [NativeTypeName("const char *")] sbyte* window_name, [NativeTypeName("const char *")] sbyte* icon_name, [NativeTypeName("char **")] sbyte** argv, int argc, [NativeTypeName("XSizeHints *")] XSizeHints* normal_hints, [NativeTypeName("XWMHints *")] XWMHints* wm_hints, [NativeTypeName("XClassHint *")] XClassHint* class_hints);
 
-        [DllImport(libraryPath, EntryPoint = "XSetWMSizeHints", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XSetWMSizeHints", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void XSetWMSizeHints([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Window")] UIntPtr w, [NativeTypeName("XSizeHints *")] XSizeHints* hints, [NativeTypeName("Atom")] UIntPtr property);
 
-        [DllImport(libraryPath, EntryPoint = "XSetRegion", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XSetRegion", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XSetRegion([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("GC")] XGC* gc, [NativeTypeName("Region")] XRegion* r);
 
-        [DllImport(libraryPath, EntryPoint = "XSetStandardColormap", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XSetStandardColormap", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void XSetStandardColormap([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Window")] UIntPtr w, [NativeTypeName("XStandardColormap *")] XStandardColormap* colormap, [NativeTypeName("Atom")] UIntPtr property);
 
-        [DllImport(libraryPath, EntryPoint = "XSetZoomHints", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XSetZoomHints", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XSetZoomHints([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("Window")] UIntPtr w, [NativeTypeName("XSizeHints *")] XSizeHints* zhints);
 
-        [DllImport(libraryPath, EntryPoint = "XShrinkRegion", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XShrinkRegion", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XShrinkRegion([NativeTypeName("Region")] XRegion* r, int dx, int dy);
 
-        [DllImport(libraryPath, EntryPoint = "XStringListToTextProperty", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XStringListToTextProperty", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XStringListToTextProperty([NativeTypeName("char **")] sbyte** list, int count, [NativeTypeName("XTextProperty *")] XTextProperty* text_prop_return);
 
-        [DllImport(libraryPath, EntryPoint = "XSubtractRegion", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XSubtractRegion", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XSubtractRegion([NativeTypeName("Region")] XRegion* sra, [NativeTypeName("Region")] XRegion* srb, [NativeTypeName("Region")] XRegion* dr_return);
 
-        [DllImport(libraryPath, EntryPoint = "XmbTextListToTextProperty", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XmbTextListToTextProperty", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XmbTextListToTextProperty([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("char **")] sbyte** list, int count, XICCEncodingStyle style, [NativeTypeName("XTextProperty *")] XTextProperty* text_prop_return);
 
-        [DllImport(libraryPath, EntryPoint = "XwcTextListToTextProperty", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XwcTextListToTextProperty", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XwcTextListToTextProperty([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("wchar_t **")] int** list, int count, XICCEncodingStyle style, [NativeTypeName("XTextProperty *")] XTextProperty* text_prop_return);
 
-        [DllImport(libraryPath, EntryPoint = "Xutf8TextListToTextProperty", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "Xutf8TextListToTextProperty", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int Xutf8TextListToTextProperty([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("char **")] sbyte** list, int count, XICCEncodingStyle style, [NativeTypeName("XTextProperty *")] XTextProperty* text_prop_return);
 
-        [DllImport(libraryPath, EntryPoint = "XwcFreeStringList", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XwcFreeStringList", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void XwcFreeStringList([NativeTypeName("wchar_t **")] int** list);
 
-        [DllImport(libraryPath, EntryPoint = "XTextPropertyToStringList", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XTextPropertyToStringList", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XTextPropertyToStringList([NativeTypeName("XTextProperty *")] XTextProperty* text_prop, [NativeTypeName("char ***")] sbyte*** list_return, [NativeTypeName("int *")] int* count_return);
 
-        [DllImport(libraryPath, EntryPoint = "XmbTextPropertyToTextList", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XmbTextPropertyToTextList", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XmbTextPropertyToTextList([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("const XTextProperty *")] XTextProperty* text_prop, [NativeTypeName("char ***")] sbyte*** list_return, [NativeTypeName("int *")] int* count_return);
 
-        [DllImport(libraryPath, EntryPoint = "XwcTextPropertyToTextList", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XwcTextPropertyToTextList", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XwcTextPropertyToTextList([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("const XTextProperty *")] XTextProperty* text_prop, [NativeTypeName("wchar_t ***")] int*** list_return, [NativeTypeName("int *")] int* count_return);
 
-        [DllImport(libraryPath, EntryPoint = "Xutf8TextPropertyToTextList", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "Xutf8TextPropertyToTextList", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int Xutf8TextPropertyToTextList([NativeTypeName("Display *")] UIntPtr display, [NativeTypeName("const XTextProperty *")] XTextProperty* text_prop, [NativeTypeName("char ***")] sbyte*** list_return, [NativeTypeName("int *")] int* count_return);
 
-        [DllImport(libraryPath, EntryPoint = "XUnionRectWithRegion", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XUnionRectWithRegion", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XUnionRectWithRegion([NativeTypeName("XRectangle *")] XRectangle* rectangle, [NativeTypeName("Region")] XRegion* src_region, [NativeTypeName("Region")] XRegion* dest_region_return);
 
-        [DllImport(libraryPath, EntryPoint = "XUnionRegion", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XUnionRegion", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XUnionRegion([NativeTypeName("Region")] XRegion* sra, [NativeTypeName("Region")] XRegion* srb, [NativeTypeName("Region")] XRegion* dr_return);
 
-        [DllImport(libraryPath, EntryPoint = "XWMGeometry", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XWMGeometry", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XWMGeometry([NativeTypeName("Display *")] UIntPtr display, int screen_number, [NativeTypeName("const char *")] sbyte* user_geometry, [NativeTypeName("const char *")] sbyte* default_geometry, [NativeTypeName("unsigned int")] uint border_width, [NativeTypeName("XSizeHints *")] XSizeHints* hints, [NativeTypeName("int *")] int* x_return, [NativeTypeName("int *")] int* y_return, [NativeTypeName("int *")] int* width_return, [NativeTypeName("int *")] int* height_return, [NativeTypeName("int *")] int* gravity_return);
 
-        [DllImport(libraryPath, EntryPoint = "XXorRegion", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "XXorRegion", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int XXorRegion([NativeTypeName("Region")] XRegion* sra, [NativeTypeName("Region")] XRegion* srb, [NativeTypeName("Region")] XRegion* dr_return);
     }
 }


### PR DESCRIPTION
This updates the package dependencies to the VS 16.5.0 Preview 1 equivalents and adds the capability for users to hook the DllImportResolver.