### PR TITLE
Target an explicit netcoreapp5.0 version and multitarget netcoreapp3.1

### DIFF
--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -120,7 +120,7 @@ try {
     $DotNetInstallDirectory = Join-Path -Path $ArtifactsDir -ChildPath "dotnet"
     Create-Directory -Path $DotNetInstallDirectory
 
-    & $DotNetInstallScript -Channel master -Version latest -InstallDir $DotNetInstallDirectory -Architecture $architecture
+    & $DotNetInstallScript -Channel master -Version "5.0.100-preview.2.20156.8" -InstallDir $DotNetInstallDirectory -Architecture $architecture
     & $DotNetInstallScript -Channel 3.1 -Version latest -InstallDir $DotNetInstallDirectory -Architecture $architecture -Runtime dotnet
 
     $env:PATH="$DotNetInstallDirectory;$env:PATH"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -204,7 +204,7 @@ if [[ ! -z "$architecture" ]]; then
   DotNetInstallDirectory="$ArtifactsDir/dotnet"
   CreateDirectory "$DotNetInstallDirectory"
 
-  . "$DotNetInstallScript" --channel master --version latest --install-dir "$DotNetInstallDirectory" --architecture "$architecture"
+  . "$DotNetInstallScript" --channel master --version "5.0.100-preview.2.20156.8" --install-dir "$DotNetInstallDirectory" --architecture "$architecture"
   . "$DotNetInstallScript" --channel 3.1 --version latest --install-dir "$DotNetInstallDirectory" --architecture "$architecture" --runtime dotnet
 
   PATH="$DotNetInstallDirectory:$PATH:"

--- a/sources/Directory.Build.targets
+++ b/sources/Directory.Build.targets
@@ -37,7 +37,7 @@
   <Target Name="GenerateSkipLocalsInit"
           BeforeTargets="CoreCompile"
           DependsOnTargets="PrepareForBuild"
-          Condition="'$(Language)' == 'C#'"
+          Condition="('$(Language)' == 'C#') AND ('$(TargetFramework)' != 'netcoreapp3.1')"
           Inputs="$(MSBuildAllProjects)"
           Outputs="$(GeneratedSkipLocalsInitFile)">
     <WriteLinesToFile Lines="$(GeneratedSkipLocalsInitFileLines)" Overwrite="true" WriteOnlyWhenDifferent="true" File="$(GeneratedSkipLocalsInitFile)" />

--- a/sources/Interop/Xlib/TerraFX.Interop.Xlib.csproj
+++ b/sources/Interop/Xlib/TerraFX.Interop.Xlib.csproj
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <NoWarn>1591;$(NoWarn)</NoWarn>
     <RootNamespace>TerraFX.Interop</RootNamespace>
-    <TargetFramework>netcoreapp5.0</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;netcoreapp5.0</TargetFrameworks>
   </PropertyGroup>
 
 </Project>

--- a/tests/Interop/Xlib/TerraFX.Interop.Xlib.UnitTests.csproj
+++ b/tests/Interop/Xlib/TerraFX.Interop.Xlib.UnitTests.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <RootNamespace>TerraFX.Interop.UnitTests</RootNamespace>
-    <TargetFramework>netcoreapp5.0</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;netcoreapp5.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This targets an explicit netcoreapp5.0 version so that builds always work and multitargets netcoreapp3.1 so this is still usable on the current LTS.